### PR TITLE
Feature/save workspace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,9 @@ if(wxWidgets_USE_FILE)
     include(${wxWidgets_USE_FILE})
 endif()
 
+message(STATUS "wx include dirs: ${wxWidgets_INCLUDE_DIRS}")
+message(STATUS "wx libraries: ${wxWidgets_LIBRARIES}")
+
 #Add flags for tests, benchmarks and other tools
 
 include(${CMAKE_SOURCE_DIR}/cmake/CPM.cmake)
@@ -119,8 +122,10 @@ message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     target_compile_definitions(DeskUp PRIVATE DEBUG_MODE)
+    target_link_options(DeskUp PRIVATE -mconsole)
 elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
     target_compile_definitions(DeskUp PRIVATE NDEBUG)
+    target_link_options(DeskUp PRIVATE -mwindows)
 endif()
 
 # --- Installation ---

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,21 +32,23 @@ if(WIN32)
         -static-libstdc++
     )
 elseif(UNIX AND NOT APPLE)
-    target_link_options(DeskUp-compiler-flags INTERFACE
-        -static-libgcc
-        -static-libstdc++
-    )
+target_link_options(DeskUp-compiler-flags INTERFACE
+-static-libgcc
+-static-libstdc++
+)
 
-    set(wxWidgets_CONFIG_EXECUTABLE "$ENV{HOME}/wx-static/bin/wx-config")
+set(wxWidgets_CONFIG_EXECUTABLE "$ENV{HOME}/wx-static/bin/wx-config")
 endif()
-    
+
 # --- Executable ---
 if (WIN32)
-    add_executable(DeskUp WIN32 source/main.cc)
-    enable_language(RC)
-    target_sources(DeskUp PRIVATE ${CMAKE_SOURCE_DIR}/resources.rc)
+add_executable(DeskUp WIN32 source/main.cc)
+enable_language(RC)
+target_sources(DeskUp PRIVATE ${CMAKE_SOURCE_DIR}/resources.rc)
 else()
     add_executable(DeskUp source/main.cc)
+    set(X11COMPATIBLE ON)
+    target_compile_definitions(DeskUp PUBLIC X11COMPATIBLE)
 endif()
 
 # --- wxWidgets static ---
@@ -90,6 +92,7 @@ endif()
 # --- Sub-libraries (without linking wxWidgets) ---
 add_subdirectory(${CMAKE_SOURCE_DIR}/source/desk_up)
 add_subdirectory(${CMAKE_SOURCE_DIR}/source/desk_up_frame)
+add_subdirectory(${CMAKE_SOURCE_DIR}/source/desk_up_window)
 
 if(WIN32)
     target_link_libraries(DeskUp PUBLIC wxWidgetsDeps)
@@ -103,6 +106,7 @@ target_link_libraries(DeskUp PRIVATE DeskUp-compiler-flags)
 target_link_libraries(DeskUp PRIVATE
     desk_up_library
     desk_up_frame_library
+    desk_up_window_library
     ${wxWidgets_LIBRARIES}
 )
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -12,7 +12,6 @@ This project was made possible thanks to the following resources:
 - [Google Tests](https://github.com/google/googletest) – Testing library.
 - [wxWidgets](https://github.com/wxWidgets/wxWidgets) – Cross-platform C++ GUI library.
 
-
 ---
 
 ## Additional Resources
@@ -30,3 +29,7 @@ Project license: [MIT](LICENSE)
 ---
 
 > Note: This file is kept updated with the credits of all people, libraries, and resources that contributed to the project.
+
+---
+
+Special thanks to [SDL](https://github.com/libsdl-org/SDL) for giving me inspiration on building this project!

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -20,14 +20,6 @@ This project was made possible thanks to the following resources:
 
 ---
 
-## Licenses
-
-Please check third-party component licenses before redistribution.  
-Project license: [MIT](LICENSE)
-[Third party Licenses](THIRD_PARTY_LICENSES.md)
-
----
-
 > Note: This file is kept updated with the credits of all people, libraries, and resources that contributed to the project.
 
 ---

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -67,3 +67,6 @@
    [] Decide the structure of the file itself: what goes inside? which pattern does it follow? (...)
 
    [] The process of saving is pretty much straightforward, but loading workspaces needs an intermediate level. Find a good way to connect the backend with this information.
+
+[] Rename some files and folders incorrectly named: class DU_windowBootstrap to DeskUpWindowBootstrap, DU_WindowDevice to DeskUpWindowDevice... this keeps
+    underscores (X11_) only for external API's or libraries

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -70,3 +70,7 @@
 
 [] Rename some files and folders incorrectly named: class DU_windowBootstrap to DeskUpWindowBootstrap, DU_WindowDevice to DeskUpWindowDevice... this keeps
     underscores (X11_) only for external API's or libraries
+
+[] choosing which device to use is not being done correctly. You need to implement it using cmake and defining macros.
+
+[] in x11 and win backends, getAllWindows functions need to set the name of the window

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -74,3 +74,5 @@
 [] choosing which device to use is not being done correctly. You need to implement it using cmake and defining macros.
 
 [] in x11 and win backends, getAllWindows functions need to set the name of the window
+
+[] Change the name of some incorrectly set classes and folders: windowDesc, DU_* Change everything DeskUp related to have DeskUpWhatever instead of DU_

--- a/include/backend_utils.h
+++ b/include/backend_utils.h
@@ -1,9 +1,12 @@
 #ifndef BACKENDUTILS_H
 #define BACKENDUTILS_H
 
-    #include <Windows.h>
+#include <Windows.h>
+#include <string>
     
-    //converts an error of windows into char. Facilitates error handling
-    const char * getSystemErrorMessageWindows(DWORD error, const char contextMessage[] = "Error: ");
-    
+//converts an error of windows into char. Facilitates error handling
+std::string getSystemErrorMessageWindows(DWORD error, const char contextMessage[] = "Error: "); 
+
+std::string WideStringToUTF8(LPWSTR wideString);
+
 #endif

--- a/include/backend_utils.h
+++ b/include/backend_utils.h
@@ -1,12 +1,9 @@
 #ifndef BACKENDUTILS_H
 #define BACKENDUTILS_H
 
-#ifdef _WIN32
     #include <Windows.h>
     
     //converts an error of windows into char. Facilitates error handling
     const char * getSystemErrorMessageWindows(DWORD error, const char contextMessage[] = "Error: ");
-
-#endif
     
 #endif

--- a/include/backend_utils.h
+++ b/include/backend_utils.h
@@ -1,9 +1,12 @@
 #ifndef BACKENDUTILS_H
 #define BACKENDUTILS_H
 
-#include <Windows.h>
+#ifdef _WIN32
+    #include <Windows.h>
+    
+    //converts an error of windows into char. Facilitates error handling
+    const char * getSystemErrorMessageWindows(DWORD error, const char contextMessage[] = "Error: ");
 
-//converts an error of windows into char. Facilitates error handling
-const char * getSystemErrorMessageWindows(DWORD error, const char contextMessage[] = "Error: ");
-
+#endif
+    
 #endif

--- a/source/desk_up_frame/CMakeLists.txt
+++ b/source/desk_up_frame/CMakeLists.txt
@@ -8,6 +8,17 @@ if(WIN32)
     target_link_libraries(desk_up_frame_library PUBLIC wxWidgetsDeps)
 endif()
 
+target_include_directories(desk_up_frame_library PUBLIC ${CMAKE_SOURCE_DIR}/source/desk_up_window)
+target_include_directories(desk_up_frame_library PUBLIC ${CMAKE_SOURCE_DIR}/source/desk_up_window_backend)
+target_include_directories(desk_up_frame_library PUBLIC ${CMAKE_SOURCE_DIR}/source/desk_up_window_backend/windowDesc)
+target_include_directories(desk_up_frame_library PUBLIC ${CMAKE_SOURCE_DIR}/source/desk_up_window_backend/window_backends/desk_up_win)
+
+add_subdirectory(${CMAKE_SOURCE_DIR}/source/desk_up_window_backend/windowDesc ${CMAKE_SOURCE_DIR}/build/source/desk_up_window_backend/windowDesc)
+
+target_link_libraries(desk_up_frame_library PUBLIC window_desc_library)
+
+target_include_directories(desk_up_frame_library PUBLIC ${CMAKE_CURRENT_LIST_DIR})
+
 target_compile_definitions(desk_up_frame_library PUBLIC wxWidgets_STATIC)
 
 target_include_directories(desk_up_frame_library PUBLIC

--- a/source/desk_up_frame/desk_up_frame.cc
+++ b/source/desk_up_frame/desk_up_frame.cc
@@ -1,11 +1,18 @@
 #include "desk_up_frame.h"
 
+#include "desk_up_window.h"
+
 DeskUpFrame::DeskUpFrame()
         : wxFrame(nullptr, wxID_ANY, "DeskUp")
 {
     #ifdef WIN32
         SetIcon(wxICON(IDI_APPLICATION));
     #endif
+
+    if(!DU_init()){
+        wxMessageBox("There was an error when initializing DeskUp. Try closing and opening the app again", "DeskUp error", wxSTAY_ON_TOP | )
+    }
+
     wxMenu *menuFile = new wxMenu;
     menuFile->Append(wxID_ADD, "Add workspace \tctrl+N");
     menuFile->AppendSeparator();
@@ -41,5 +48,25 @@ void DeskUpFrame::OnAbout(wxCommandEvent& event)
 
 void DeskUpFrame::OnAdd(wxCommandEvent& event)
 {
-    wxLogMessage("You will add a workspace here :)! Be patient");
+    const wxString workspaceName;
+
+    while(1){
+
+        wxTextEntryDialog createWorkspace(this, "Enter the workspace name", "Add workspace");
+        
+        if(createWorkspace.ShowModal() == wxID_OK){
+            workspaceName = createWorkspace.GetValue();
+
+            if(!workspaceName.empty()){
+                break;
+            } else{
+                wxMessageBox("Your workspace name cannot be empty!", "Workspace name", wxOK | wxICON_INFORMATION, createWorkspace);
+            }
+        } else{
+            break;
+        }
+    }
+
+    DeskUpWindow::saveAllWindowsLocal(workspaceName.c_str());
+
 }

--- a/source/desk_up_frame/desk_up_frame.cc
+++ b/source/desk_up_frame/desk_up_frame.cc
@@ -1,6 +1,7 @@
 #include "desk_up_frame.h"
 
 #include "desk_up_window.h"
+#include "window_global.h"
 
 DeskUpFrame::DeskUpFrame()
         : wxFrame(nullptr, wxID_ANY, "DeskUp")
@@ -9,8 +10,8 @@ DeskUpFrame::DeskUpFrame()
         SetIcon(wxICON(IDI_APPLICATION));
     #endif
 
-    if(!DU_init()){
-        wxMessageBox("There was an error when initializing DeskUp. Try closing and opening the app again", "DeskUp error", wxSTAY_ON_TOP | )
+    if(!DU_Init((HWND) this->GetHandle())){
+        wxMessageBox("There was an error when initializing DeskUp. Try closing and opening the app again", "DeskUp error", wxSTAY_ON_TOP);
     }
 
     wxMenu *menuFile = new wxMenu;
@@ -48,25 +49,30 @@ void DeskUpFrame::OnAbout(wxCommandEvent& event)
 
 void DeskUpFrame::OnAdd(wxCommandEvent& event)
 {
-    const wxString workspaceName;
+    wxString workspaceName;
 
     while(1){
 
         wxTextEntryDialog createWorkspace(this, "Enter the workspace name", "Add workspace");
         
-        if(createWorkspace.ShowModal() == wxID_OK){
-            workspaceName = createWorkspace.GetValue();
+        if(createWorkspace.ShowModal() != wxID_OK){
+            return;
+        } 
 
-            if(!workspaceName.empty()){
-                break;
-            } else{
-                wxMessageBox("Your workspace name cannot be empty!", "Workspace name", wxOK | wxICON_INFORMATION, createWorkspace);
-            }
-        } else{
+        workspaceName = createWorkspace.GetValue();
+
+        if(!workspaceName.empty()){
             break;
         }
+        
+        wxMessageBox("Your workspace name cannot be empty!", "Workspace name", wxOK | wxICON_INFORMATION);
     }
+    
+    std::cout << workspaceName;
 
-    DeskUpWindow::saveAllWindowsLocal(workspaceName.c_str());
+    if (!DeskUpWindow::saveAllWindowsLocal(workspaceName.ToStdString())){
+        wxMessageBox("Something went wrong! Please restart Desk Up", "Desk Up error", wxOK | wxICON_INFORMATION);
+        wxExit();
+    }
 
 }

--- a/source/desk_up_frame/desk_up_frame.h
+++ b/source/desk_up_frame/desk_up_frame.h
@@ -1,3 +1,6 @@
+#ifndef DESKUPFRAME_H
+#define DESKUPFRAME_H
+
 #include <wx/wx.h>
 
 class DeskUpFrame : public wxFrame{
@@ -9,3 +12,5 @@ class DeskUpFrame : public wxFrame{
     void OnExit(wxCommandEvent& event);
     void OnAbout(wxCommandEvent& event);
 };
+
+#endif

--- a/source/desk_up_window/CMakeLists.txt
+++ b/source/desk_up_window/CMakeLists.txt
@@ -7,11 +7,15 @@ target_include_directories(desk_up_window_library PUBLIC ${CMAKE_SOURCE_DIR}/sou
 target_include_directories(desk_up_window_library PUBLIC ${CMAKE_SOURCE_DIR}/source/desk_up_window_backend/windowDesc)
 target_include_directories(desk_up_window_library PUBLIC ${CMAKE_SOURCE_DIR}/include)
 
-add_subdirectory(${CMAKE_SOURCE_DIR}/source/desk_up_window_backend/window_backends/desk_up_win)
+add_subdirectory(${CMAKE_SOURCE_DIR}/source/desk_up_window_backend/window_backends/desk_up_win
+                 ${CMAKE_SOURCE_DIR}/build/source/desk_up_window_backend/window_backends/desk_up_win)
 
 target_link_libraries(desk_up_window_library PUBLIC desk_up_win_library)
 
-target_sources(desk_up_window_library PUBLIC ${CMAKE_SOURCE_DIR}/include/backend_uitls.h)
+target_sources(desk_up_window_library PUBLIC ${CMAKE_SOURCE_DIR}/include/backend_utils.h)
 
-target_sources(desk_up_window_library PUBLIC ${CMAKE_SOURCE_DIR}/source/desk_up_window_backend/backend_uitls.cc)
+target_sources(desk_up_window_library PUBLIC ${CMAKE_SOURCE_DIR}/source/desk_up_window_backend/backend_utils.cc)
+target_sources(desk_up_window_library PUBLIC ${CMAKE_SOURCE_DIR}/source/desk_up_window_backend/window_global.h)
 target_sources(desk_up_window_library PUBLIC ${CMAKE_SOURCE_DIR}/source/desk_up_window_backend/window_global.cc)
+target_sources(desk_up_window_library PUBLIC ${CMAKE_SOURCE_DIR}/source/desk_up_window_backend/desk_up_window_device.h)
+target_sources(desk_up_window_library PUBLIC ${CMAKE_SOURCE_DIR}/source/desk_up_window_backend/desk_up_window_bootstrap.h)

--- a/source/desk_up_window/CMakeLists.txt
+++ b/source/desk_up_window/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_library(desk_up_window_library)
+
+target_sources(desk_up_window_library PUBLIC ${CMAKE_CURRENT_LIST_DIR}/desk_up_window.h ${CMAKE_CURRENT_LIST_DIR}/desk_up_window.cc)
+
+target_include_directories(desk_up_window_library PUBLIC ${CMAKE_SOURCE_DIR}/source/desk_up_window_backend)
+target_include_directories(desk_up_window_library PUBLIC ${CMAKE_SOURCE_DIR}/source/desk_up_window_backend/window_backends/desk_up_win)
+target_include_directories(desk_up_window_library PUBLIC ${CMAKE_SOURCE_DIR}/source/desk_up_window_backend/windowDesc)
+target_include_directories(desk_up_window_library PUBLIC ${CMAKE_SOURCE_DIR}/include)
+
+add_subdirectory(${CMAKE_SOURCE_DIR}/source/desk_up_window_backend/window_backends/desk_up_win)
+
+target_link_libraries(desk_up_window_library PUBLIC desk_up_win_library)
+
+target_sources(desk_up_window_library PUBLIC ${CMAKE_SOURCE_DIR}/include/backend_uitls.h)
+
+target_sources(desk_up_window_library PUBLIC ${CMAKE_SOURCE_DIR}/source/desk_up_window_backend/backend_uitls.cc)
+target_sources(desk_up_window_library PUBLIC ${CMAKE_SOURCE_DIR}/source/desk_up_window_backend/window_global.cc)

--- a/source/desk_up_window/desk_up_window.cc
+++ b/source/desk_up_window/desk_up_window.cc
@@ -1,27 +1,42 @@
 #include "desk_up_window.h"
 
 #include <vector>
+#include <string>
+#include <filesystem>
 
 #include "window_global.h"
 
 int DeskUpWindow::saveAllWindowsLocal(std::string workspaceName){
     
     std::string workspacePath = DESKUPDIR;
-    workspacePath += "/";
+    workspacePath += "\\";
     workspacePath += workspaceName;
+    std::filesystem::create_directory((std::filesystem::path) workspacePath);
 
-    std::vector<windowDesc> windows = current_window_backend->getAllWindows(current_window_backend);
+    std::vector<windowDesc> windows;
+    try{
+        windows = current_window_backend->getAllWindows(current_window_backend);
+    } catch(std::runtime_error &e){
+        std::cout << e.what();
+        return 0;
+    } catch(...){
+        std::cout << "Unexpected something";
+        return 0;
+    }
 
     for(unsigned int i = 0; i < windows.size(); i++){
         
         //create path
         std::string filePath(workspacePath);
-        filePath += "/";
+        filePath += "\\";
         filePath += windows[i].name;
+
+
+        std::cout << filePath << std::endl;
         
         if(!windows[i].saveTo(filePath)){
-            //if any fails, the action gets aborted and user will be notified in the caller
-            return 0;
+            std::cout << windows[i].name << " could not be saved to local";
+            continue;
         }
     }
 

--- a/source/desk_up_window/desk_up_window.cc
+++ b/source/desk_up_window/desk_up_window.cc
@@ -1,0 +1,29 @@
+#include "desk_up_window.h"
+
+#include <vector>
+
+#include "window_global.h"
+
+int DeskUpWindow::saveAllWindowsLocal(std::string workspaceName){
+    
+    std::string workspacePath = DESKUPDIR;
+    workspacePath += "/";
+    workspacePath += workspaceName;
+
+    std::vector<windowDesc> windows = current_window_backend->getAllWindows(current_window_backend);
+
+    for(unsigned int i = 0; i < windows.size(); i++){
+        
+        //create path
+        std::string filePath(workspacePath);
+        filePath += "/";
+        filePath += windows[i].name;
+        
+        if(!windows[i].saveTo(filePath)){
+            //if any fails, the action gets aborted and user will be notified in the caller
+            return 0;
+        }
+    }
+
+    return 1;
+}   

--- a/source/desk_up_window/desk_up_window.h
+++ b/source/desk_up_window/desk_up_window.h
@@ -5,6 +5,6 @@
 
 typedef struct DeskUpWindow{
     static int saveAllWindowsLocal(std::string workspaceName);
-};
+} DeskUpWindow;
 
 #endif

--- a/source/desk_up_window/desk_up_window.h
+++ b/source/desk_up_window/desk_up_window.h
@@ -1,0 +1,10 @@
+#ifndef DESKUPWINDOW_H
+#define DESKUPWINDOW_H
+
+#include <string>
+
+typedef struct DeskUpWindow{
+    static int saveAllWindowsLocal(std::string workspaceName);
+};
+
+#endif

--- a/source/desk_up_window_backend/backend_utils.cc
+++ b/source/desk_up_window_backend/backend_utils.cc
@@ -1,7 +1,10 @@
 #include "backend_utils.h"
 
+#ifdef _WIN32
+
 #include <stdlib.h>
 #include <string>
+
 
 const char * getSystemErrorMessageWindows(DWORD error, const char contextMessage[]){
     
@@ -28,3 +31,5 @@ const char * getSystemErrorMessageWindows(DWORD error, const char contextMessage
 
     return errMessage.c_str();
 }
+
+#endif

--- a/source/desk_up_window_backend/backend_utils.cc
+++ b/source/desk_up_window_backend/backend_utils.cc
@@ -1,7 +1,5 @@
 #include "backend_utils.h"
 
-#ifdef _WIN32
-
 #include <stdlib.h>
 #include <string>
 
@@ -31,5 +29,3 @@ const char * getSystemErrorMessageWindows(DWORD error, const char contextMessage
 
     return errMessage.c_str();
 }
-
-#endif

--- a/source/desk_up_window_backend/backend_utils.cc
+++ b/source/desk_up_window_backend/backend_utils.cc
@@ -1,31 +1,90 @@
 #include "backend_utils.h"
 
 #include <stdlib.h>
-#include <string>
 
 
-const char * getSystemErrorMessageWindows(DWORD error, const char contextMessage[]){
+std::string getSystemErrorMessageWindows(DWORD error, const char contextMessage[]) {
+    if (!error) return "unknown error passed as parameter!";
+
+    LPWSTR messageBuffer = nullptr; // FormatMessage will allocate
+    DWORD flags = FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS;
     
-    if(!error){
-        return "unknown error passed as parameter!";
+    DWORD charsWritten = FormatMessageW(
+        flags,
+        nullptr,
+        error,
+        0,                  // Language ID
+        reinterpret_cast<LPWSTR>(&messageBuffer),
+        0,
+        nullptr
+    );
+
+    std::string finalMessage;
+
+    if (charsWritten) {
+        // Convert from wide-char to UTF-8
+        std::string utf8Buffer = WideStringToUTF8(messageBuffer);
+        if (!utf8Buffer.empty()) {
+            finalMessage = contextMessage;
+            finalMessage += utf8Buffer;
+        }
+        LocalFree(messageBuffer);
+    } else {
+        finalMessage = contextMessage;
+        finalMessage += "Unknown Windows error.";
     }
-    
-    LPWSTR message;
 
-    auto errorType = FORMAT_MESSAGE_FROM_SYSTEM;
-    auto returnLang = LANG_SYSTEM_DEFAULT;
-    int returnSize = 500;
-    va_list * args = nullptr;
+    return finalMessage;
+}
 
-    FormatMessage(errorType, 0, error, returnLang, message, returnSize, args);
 
-    //convert from wanky windows type to char
-    char buffer[returnSize];
+std::string WideStringToUTF8(LPWSTR wideString) {
+    if (!wideString) return "";
 
-    wcstombs(buffer, message, returnSize);
+    // Input for size calculation
+    UINT codePage = CP_UTF8;                 // Convert to UTF-8
+    DWORD conversionFlags = 0;               // No special flags
+    LPCWCH sourceWideString = wideString;   // Input UTF-16 string
+    int inputCharacterCount = -1;            // Null-terminated
+    LPSTR destinationBuffer = nullptr;       // No buffer yet, we only calculate size
+    int destinationBufferSize = 0;           // Buffer size = 0
+    LPCCH defaultChar = nullptr;             // Not used
+    LPBOOL usedDefaultChar = nullptr;        // Not used
 
-    std::string errMessage = contextMessage;
-    errMessage += buffer;
+    // Get required buffer size for UTF-8 string (including null terminator)
+    int utf8ByteCount = WideCharToMultiByte(
+        codePage,
+        conversionFlags,
+        sourceWideString,
+        inputCharacterCount,
+        destinationBuffer,
+        destinationBufferSize,
+        defaultChar,
+        usedDefaultChar
+    );
 
-    return errMessage.c_str();
+    if (utf8ByteCount <= 0) return "";
+
+    // Allocate string to hold the UTF-8 result
+    std::string utf8String(utf8ByteCount - 1, 0); // exclude null terminator
+
+    // Set up the parameters again for the actual conversion
+    destinationBuffer = utf8String.data();
+    destinationBufferSize = utf8ByteCount;
+
+    // Perform the conversion
+    int convertedBytes = WideCharToMultiByte(
+        codePage,
+        conversionFlags,
+        sourceWideString,
+        inputCharacterCount,
+        destinationBuffer,
+        destinationBufferSize,
+        defaultChar,
+        usedDefaultChar
+    );
+
+    if (convertedBytes <= 0) return "";
+
+    return utf8String;
 }

--- a/source/desk_up_window_backend/desk_up_window_bootstrap.h
+++ b/source/desk_up_window_backend/desk_up_window_bootstrap.h
@@ -2,10 +2,11 @@
 #define DESKUPWINDOWBOOSTRAP_H
 
 #include "desk_up_window_device.h"
+#include <Windows.h>
 
 struct DU_WindowBootStrap{
     const char * name;
-    DU_windowDevice * (*createDevice)(void);
+    DU_windowDevice * (*createDevice)(HWND);
 };
 
 #endif

--- a/source/desk_up_window_backend/desk_up_window_bootstrap.h
+++ b/source/desk_up_window_backend/desk_up_window_bootstrap.h
@@ -1,0 +1,11 @@
+#ifndef DESKUPWINDOWBOOSTRAP_H
+#define DESKUPWINDOWBOOSTRAP_H
+
+#include "desk_up_window_device.h"
+
+struct DU_WindowBootStrap{
+    const char * name;
+    DU_windowDevice * (*createDevice)(void);
+};
+
+#endif

--- a/source/desk_up_window_backend/desk_up_window_device.h
+++ b/source/desk_up_window_backend/desk_up_window_device.h
@@ -1,0 +1,21 @@
+#ifndef DESKUPWINDOWDEVICE_H
+#define DESKUPWINDOWDEVICE_H
+
+#include <vector>
+#include <string>
+#include "windowDesc.h"
+
+struct DU_windowDevice{
+    //here goes all the generic functions that all the backends have
+    unsigned int (*getWindowHeight)(DU_windowDevice * _this);
+    unsigned int (*getWindowWidth)(DU_windowDevice * _this);
+    unsigned int (*getWindowXPos)(DU_windowDevice * _this);
+    unsigned int (*getWindowYPos)(DU_windowDevice * _this);
+    std::string (*getDeskUpPath)(void);
+    
+    std::vector<windowDesc> (*getAllWindows)(DU_windowDevice * _this);
+
+    void * internalData;
+};
+
+#endif

--- a/source/desk_up_window_backend/windowDesc/CMakeLists.txt
+++ b/source/desk_up_window_backend/windowDesc/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_library(window_desc_library STATIC)
+
+target_include_directories(window_desc_library PUBLIC ${CMAKE_SOURCE_DIR}/source/desk_up_window_backend)
+
+target_sources(window_desc_library PUBLIC ${CMAKE_CURRENT_LIST_DIR}/windowDesc.cc ${CMAKE_CURRENT_LIST_DIR}/windowDesc.h)

--- a/source/desk_up_window_backend/windowDesc/windowDesc.cc
+++ b/source/desk_up_window_backend/windowDesc/windowDesc.cc
@@ -1,0 +1,30 @@
+#include "windowDesc.h"
+
+#include <fstream>
+
+
+int windowDesc::saveTo(std::string path){
+    
+    if(path.empty()){
+        return 0;
+    }
+    
+    std::ofstream windowFile;
+
+    windowFile.open(path, std::ios::out);
+
+    if(!windowFile.is_open()){
+        return 0;
+    }
+
+
+    windowFile << this->pathToExec 
+    << std::endl << this->x 
+    << std::endl << this->y 
+    << std::endl << this->w 
+    << std::endl << this->h;
+
+    windowFile.close();
+
+    return 1;
+}

--- a/source/desk_up_window_backend/windowDesc/windowDesc.cc
+++ b/source/desk_up_window_backend/windowDesc/windowDesc.cc
@@ -1,11 +1,12 @@
 #include "windowDesc.h"
 
 #include <fstream>
-
+#include <iostream>
 
 int windowDesc::saveTo(std::string path){
     
     if(path.empty()){
+        std::cout << "file path empty" << std::endl;
         return 0;
     }
     

--- a/source/desk_up_window_backend/windowDesc/windowDesc.h
+++ b/source/desk_up_window_backend/windowDesc/windowDesc.h
@@ -5,8 +5,11 @@
 
 // this is an abstract struct that saves all the info needed to restore a window to its original state  
 typedef struct windowDesc{
+    char * name;
     int x,y,w,h;
     std::string pathToExec;
+
+    int saveTo(std::string path);
 
     bool operator!() const {
         return !x && !y && !w && !h;

--- a/source/desk_up_window_backend/windowDesc/windowDesc.h
+++ b/source/desk_up_window_backend/windowDesc/windowDesc.h
@@ -5,7 +5,7 @@
 
 // this is an abstract struct that saves all the info needed to restore a window to its original state  
 typedef struct windowDesc{
-    char * name;
+    std::string name;
     int x,y,w,h;
     std::string pathToExec;
 
@@ -14,6 +14,6 @@ typedef struct windowDesc{
     bool operator!() const {
         return !x && !y && !w && !h;
     }
-};
+} windowDesc;
 
 #endif

--- a/source/desk_up_window_backend/window_backends/desk_up_win/CMakeLists.txt
+++ b/source/desk_up_window_backend/window_backends/desk_up_win/CMakeLists.txt
@@ -1,11 +1,21 @@
 add_library(desk_up_win_library STATIC)
 
-# here goes he equivalent for win32
-# target_include_directories(desk_up_win_library PUBLIC ${X11_INCLUDE_DIR})
-# target_link_libraries(desk_up_win_library PUBLIC ${X11_LIBRARIES})
 
 target_include_directories(desk_up_win_library PUBLIC ${CMAKE_SOURCE_DIR}/source/desk_up_window_backend)
 
 target_include_directories(desk_up_win_library PUBLIC ${CMAKE_CURRENT_LIST_DIR})
 
+target_include_directories(desk_up_win_library PUBLIC ${CMAKE_SOURCE}/include)
+
+target_include_directories(desk_up_x11_library PUBLIC ${CMAKE_SOURCE_DIR}/source/desk_up_window_backend/windowDesc)
+target_link_libraries(desk_up_x11_library PUBLIC window_desc_library)
+
 target_sources(desk_up_win_library PUBLIC ${CMAKE_CURRENT_LIST_DIR}/desk_up_win.cc ${CMAKE_CURRENT_LIST_DIR}/desk_up_win.h)
+
+target_link_libraries(desk_up_win_library PUBLIC 
+    user32
+    gdi32
+    kernel32
+    advapi32
+    comdlg32
+    shell32)

--- a/source/desk_up_window_backend/window_backends/desk_up_win/CMakeLists.txt
+++ b/source/desk_up_window_backend/window_backends/desk_up_win/CMakeLists.txt
@@ -5,10 +5,10 @@ target_include_directories(desk_up_win_library PUBLIC ${CMAKE_SOURCE_DIR}/source
 
 target_include_directories(desk_up_win_library PUBLIC ${CMAKE_CURRENT_LIST_DIR})
 
-target_include_directories(desk_up_win_library PUBLIC ${CMAKE_SOURCE}/include)
+target_include_directories(desk_up_win_library PUBLIC ${CMAKE_SOURCE_DIR}/include)
 
-target_include_directories(desk_up_x11_library PUBLIC ${CMAKE_SOURCE_DIR}/source/desk_up_window_backend/windowDesc)
-target_link_libraries(desk_up_x11_library PUBLIC window_desc_library)
+target_include_directories(desk_up_win_library PUBLIC ${CMAKE_SOURCE_DIR}/source/desk_up_window_backend/windowDesc)
+target_link_libraries(desk_up_win_library PUBLIC window_desc_library)
 
 target_sources(desk_up_win_library PUBLIC ${CMAKE_CURRENT_LIST_DIR}/desk_up_win.cc ${CMAKE_CURRENT_LIST_DIR}/desk_up_win.h)
 

--- a/source/desk_up_window_backend/window_backends/desk_up_win/desk_up_win.cc
+++ b/source/desk_up_window_backend/window_backends/desk_up_win/desk_up_win.cc
@@ -2,7 +2,7 @@
 
 #include "backend_utils.h"
 
-bool WIN_isAvailable(DU_WindowDevice *){
+bool WIN_isAvailable(DU_windowDevice *){
     #ifdef _WIN32
         return true;
     #endif
@@ -10,10 +10,10 @@ bool WIN_isAvailable(DU_WindowDevice *){
     return false;
 }
 
-DU_WindowDevice * WIN_CreateDevice(void){
+DU_windowDevice * WIN_CreateDevice(void){
     //set all the functions of a DU_windowDevice variable to the functions of x11. Also set internalData to 
 
-    DU_WindowDevice * device = nullptr;
+    DU_windowDevice * device = nullptr;
 
     device->getWindowHeight = WIN_getWindowHeight;
     device->isAvailable = WIN_isAvailable;
@@ -25,7 +25,7 @@ DU_WindowDevice * WIN_CreateDevice(void){
     return device;
 }
 
-unsigned int WIN_getWindowHeight(DU_WindowDevice * _this){
+unsigned int WIN_getWindowHeight(DU_windowDevice * _this){
     const windowData * data = (windowData *) _this->internalData;
     
     if(!data->hwnd){
@@ -50,7 +50,7 @@ unsigned int WIN_getWindowHeight(DU_WindowDevice * _this){
     return height;
 }
 
-unsigned int WIN_getWindowWidth(DU_WindowDevice * _this){
+unsigned int WIN_getWindowWidth(DU_windowDevice * _this){
     const windowData * data = (windowData *) _this->internalData;
     
     if(!data->hwnd){
@@ -75,7 +75,7 @@ unsigned int WIN_getWindowWidth(DU_WindowDevice * _this){
     return width;
 }
 
-unsigned int WIN_getWindowXPos(DU_WindowDevice * _this){
+unsigned int WIN_getWindowXPos(DU_windowDevice * _this){
     const windowData * data = (windowData *) _this->internalData;
     
     if(!data->hwnd){
@@ -99,7 +99,7 @@ unsigned int WIN_getWindowXPos(DU_WindowDevice * _this){
     return x;
 }
 
-unsigned int WIN_getWindowYPos(DU_WindowDevice * _this){
+unsigned int WIN_getWindowYPos(DU_windowDevice * _this){
     const windowData * data = (windowData *) _this->internalData;
     
     if(!data->hwnd){
@@ -124,7 +124,7 @@ unsigned int WIN_getWindowYPos(DU_WindowDevice * _this){
 }
 
 //every os works with different types for interpreting paths, so work with std 
-char * WIN_GetPathFromWindow(DU_WindowDevice * _this){
+char * WIN_GetPathFromWindow(DU_windowDevice * _this){
 
     const windowData * data = (windowData *) _this->internalData;
     
@@ -180,11 +180,11 @@ char * WIN_GetPathFromWindow(DU_WindowDevice * _this){
 
 BOOL CALLBACK WIN_createAndSaveWindow(HWND hwnd, LPARAM lparam){
 
-    //recover the parameters once we are inside. We can now use both DU_WindowDevice and fill the vector with windows
-    std::pair<std::vector<windowDesc> *, DU_WindowDevice *> * parameters = (std::pair<std::vector<windowDesc> *, DU_WindowDevice *> *) reinterpret_cast<void *>(lparam);
+    //recover the parameters once we are inside. We can now use both DU_windowDevice and fill the vector with windows
+    std::pair<std::vector<windowDesc> *, DU_windowDevice *> * parameters = (std::pair<std::vector<windowDesc> *, DU_windowDevice *> *) reinterpret_cast<void *>(lparam);
 
     std::vector<windowDesc> * windows = parameters->first;
-    DU_WindowDevice * dev = parameters->second;
+    DU_windowDevice * dev = parameters->second;
 
     if(windows == nullptr){
         std::cout << "The vector of windows could not be passed to the callback!" << std::endl;
@@ -229,18 +229,18 @@ BOOL CALLBACK WIN_createAndSaveWindow(HWND hwnd, LPARAM lparam){
     return TRUE;
 }
 
-std::vector<windowDesc> WIN_getAllWindows(DU_WindowDevice * _this){
+std::vector<windowDesc> WIN_getAllWindows(DU_windowDevice * _this){
     
     std::vector<windowDesc> windows;
 
-    std::pair<std::vector<windowDesc> *, DU_WindowDevice *> * callbackParameters;
+    std::pair<std::vector<windowDesc> *, DU_windowDevice *> * callbackParameters;
 
     callbackParameters->first = &windows;
     callbackParameters->second = _this;
     
     HDESK desktop = NULL;
 
-    //we need to "fit" both the vector of the windows and the own DU_WindowDevice inside the callback inside LPARAM
+    //we need to "fit" both the vector of the windows and the own DU_windowDevice inside the callback inside LPARAM
     if(!EnumDesktopWindows(desktop, /*callback*/ WIN_createAndSaveWindow, reinterpret_cast<LPARAM>((void *) &callbackParameters))){
         DWORD error = GetLastError();
         const char * errorMessage = getSystemErrorMessageWindows(error);

--- a/source/desk_up_window_backend/window_backends/desk_up_win/desk_up_win.cc
+++ b/source/desk_up_window_backend/window_backends/desk_up_win/desk_up_win.cc
@@ -197,23 +197,20 @@ std::string WIN_GetPathFromWindow(DU_windowDevice* _this) {
     return result;
 }
 
-std::string WIN_GetNameFromPath(std::string path){
-
-    if(path.empty()){
+std::string WIN_GetNameFromPath(const std::string& path) {
+    if (path.empty()) {
+        std::cerr << "path is empty\n";
         return "";
     }
 
-    std::string name = "";
-
-    for(int i = path.length() - 1; i >= 0; i--){
-        if(path[i] != '\\'){
-            name += path[i];
-        } else{
-            return name;
-        }
+    std::string name;
+    for (int i = (int)path.length() - 1; i >= 0; --i) {
+        if (path[i] == '\\' || path[i] == '/')
+            break;
+        name.insert(name.begin(), path[i]);
     }
 
-    return name;
+    return name.substr(0, name.size() - 4);
 }
 
 BOOL CALLBACK WIN_createAndSaveWindow(HWND hwnd, LPARAM lparam){
@@ -260,9 +257,9 @@ BOOL CALLBACK WIN_createAndSaveWindow(HWND hwnd, LPARAM lparam){
 
         window.pathToExec = WIN_GetPathFromWindow(dev);
         
-        window.name = WIN_GetNameFromPath(window.name);
+        std::cout << window.pathToExec << std::endl;
+        window.name = WIN_GetNameFromPath(window.pathToExec);
 
-        std::cout << window.pathToExec;
         //after that erase it so that we dont use a previous hwnd by accident
         reinterpret_cast<windowData*>(dev->internalData)->hwnd = nullptr;
 

--- a/source/desk_up_window_backend/window_backends/desk_up_win/desk_up_win.cc
+++ b/source/desk_up_window_backend/window_backends/desk_up_win/desk_up_win.cc
@@ -1,21 +1,26 @@
 #include "desk_up_win.h"
 
-#include "backend_utils.h"
+#include <string>
+#include <cstdlib>
 
-bool WIN_isAvailable(DU_windowDevice *){
-    #ifdef _WIN32
-        return true;
-    #endif
-    
-    return false;
-}
+#include "backend_utils.h"
 
 DU_windowDevice * WIN_CreateDevice(void){
     //set all the functions of a DU_windowDevice variable to the functions of x11. Also set internalData to 
 
+    std::string workspacePath = std::getenv("APPDATA");
+
+    workspacePath += "DeskUp";
+
+    DESKUPDIR = workspacePath.c_str();
+
     DU_windowDevice * device = nullptr;
 
     device->getWindowHeight = WIN_getWindowHeight;
+    device->getWindowWidth = WIN_getWindowWidth;
+    device->getWindowXPos = WIN_getWindowXPos;
+    device->getWindowYPos = WIN_getWindowYPos;
+    device->getAllWindows = WIN_getAllWindows;
     device->isAvailable = WIN_isAvailable;
 
     windowData * data;

--- a/source/desk_up_window_backend/window_backends/desk_up_win/desk_up_win.cc
+++ b/source/desk_up_window_backend/window_backends/desk_up_win/desk_up_win.cc
@@ -8,9 +8,11 @@
 
 #include "backend_utils.h"
 
+std::unique_ptr<HWND> desk_up_hwnd = nullptr;
+
 struct windowData{
     HWND hwnd;
-};
+};  
 
 DU_WindowBootStrap winWindowDevice = {
     "win",
@@ -240,6 +242,11 @@ BOOL CALLBACK WIN_createAndSaveWindow(HWND hwnd, LPARAM lparam){
         return FALSE;
     }
 
+    //skip deskUp
+    if(*desk_up_hwnd.get() == hwnd){
+        return TRUE;
+    }
+
     //fill a new windowDesc and push it to 'windows'
 
     windowDesc window;
@@ -303,8 +310,12 @@ std::vector<windowDesc> WIN_getAllWindows(DU_windowDevice * _this){
 }
 
 
-DU_windowDevice * WIN_CreateDevice(void){
+DU_windowDevice * WIN_CreateDevice(HWND deskUpHWND){
     //set all the functions of a DU_windowDevice variable to the functions of x11. Also set internalData to 
+
+    if(deskUpHWND){
+        desk_up_hwnd = std::make_unique<HWND>(deskUpHWND);
+    }
 
     DU_windowDevice * device;
 
@@ -322,7 +333,9 @@ DU_windowDevice * WIN_CreateDevice(void){
     device->getAllWindows = WIN_getAllWindows;
     device->getDeskUpPath = WIN_getDeskUpPath;
 
-    device->internalData = (void *) new windowData;
+    device->internalData = (void *) new windowData();
+
+    
     
     return device;
 }

--- a/source/desk_up_window_backend/window_backends/desk_up_win/desk_up_win.h
+++ b/source/desk_up_window_backend/window_backends/desk_up_win/desk_up_win.h
@@ -23,16 +23,16 @@ DU_WindowBootStrap winWindowDevice = {
 };
 
 
-DU_WindowDevice * WIN_CreateDevice(void);
-bool WIN_isAvailable(DU_WindowDevice *);
+DU_windowDevice * WIN_CreateDevice(void);
+bool WIN_isAvailable(DU_windowDevice *);
 
-unsigned int WIN_getWindowHeight(DU_WindowDevice * _this);
-unsigned int WIN_getWindowWidth(DU_WindowDevice * _this);
-unsigned int WIN_getWindowXPos(DU_WindowDevice * _this);
-unsigned int WIN_getWindowYPos(DU_WindowDevice * _this);
+unsigned int WIN_getWindowHeight(DU_windowDevice * _this);
+unsigned int WIN_getWindowWidth(DU_windowDevice * _this);
+unsigned int WIN_getWindowXPos(DU_windowDevice * _this);
+unsigned int WIN_getWindowYPos(DU_windowDevice * _this);
 
-char * WIN_GetPathFromWindow(DU_WindowDevice * _this);
+char * WIN_GetPathFromWindow(DU_windowDevice * _this);
 
-std::vector<windowDesc> WIN_getAllWindows(DU_WindowDevice * _this);
+std::vector<windowDesc> WIN_getAllWindows(DU_windowDevice * _this);
 
 #endif

--- a/source/desk_up_window_backend/window_backends/desk_up_win/desk_up_win.h
+++ b/source/desk_up_window_backend/window_backends/desk_up_win/desk_up_win.h
@@ -7,30 +7,29 @@
 #include <filesystem>
 #include <stdlib.h>
 
-#include "window_global.h"
 #include "windowDesc.h"
+#include "desk_up_window_bootstrap.h"
+#include "desk_up_window_device.h"
 
 // here we define API calls, like WIN_getWindowHeight()
 //we also declare a struct data that carries specific information that the backend needs
 
-typedef struct windowData{
-    HWND hwnd;
-};
+struct DU_WindowBootStrap;
+struct DU_windowDevice;
 
-DU_WindowBootStrap winWindowDevice = {
-    "win",
-    WIN_CreateDevice
-};
-
+struct windowData;
 
 DU_windowDevice * WIN_CreateDevice(void);
 
+extern DU_WindowBootStrap winWindowDevice;
+
+std::string WIN_getDeskUpPath();
 unsigned int WIN_getWindowHeight(DU_windowDevice * _this);
 unsigned int WIN_getWindowWidth(DU_windowDevice * _this);
 unsigned int WIN_getWindowXPos(DU_windowDevice * _this);
 unsigned int WIN_getWindowYPos(DU_windowDevice * _this);
 
-char * WIN_GetPathFromWindow(DU_windowDevice * _this);
+std::string WIN_GetPathFromWindow(DU_windowDevice * _this);
 
 std::vector<windowDesc> WIN_getAllWindows(DU_windowDevice * _this);
 

--- a/source/desk_up_window_backend/window_backends/desk_up_win/desk_up_win.h
+++ b/source/desk_up_window_backend/window_backends/desk_up_win/desk_up_win.h
@@ -24,7 +24,6 @@ DU_WindowBootStrap winWindowDevice = {
 
 
 DU_windowDevice * WIN_CreateDevice(void);
-bool WIN_isAvailable(DU_windowDevice *);
 
 unsigned int WIN_getWindowHeight(DU_windowDevice * _this);
 unsigned int WIN_getWindowWidth(DU_windowDevice * _this);
@@ -34,5 +33,7 @@ unsigned int WIN_getWindowYPos(DU_windowDevice * _this);
 char * WIN_GetPathFromWindow(DU_windowDevice * _this);
 
 std::vector<windowDesc> WIN_getAllWindows(DU_windowDevice * _this);
+
+
 
 #endif

--- a/source/desk_up_window_backend/window_backends/desk_up_win/desk_up_win.h
+++ b/source/desk_up_window_backend/window_backends/desk_up_win/desk_up_win.h
@@ -19,7 +19,7 @@ struct DU_windowDevice;
 
 struct windowData;
 
-DU_windowDevice * WIN_CreateDevice(void);
+DU_windowDevice * WIN_CreateDevice(HWND deskUpHWND);
 
 extern DU_WindowBootStrap winWindowDevice;
 

--- a/source/desk_up_window_backend/window_backends/desk_up_x11/CMakeLists.txt
+++ b/source/desk_up_window_backend/window_backends/desk_up_x11/CMakeLists.txt
@@ -1,13 +1,14 @@
-find_package(X11 REQUIRED)
+# find_package(X11 REQUIRED)
 
-add_library(desk_up_x11_library STATIC)
+# add_library(desk_up_x11_library STATIC)
 
-target_include_directories(desk_up_x11_library PUBLIC ${CMAKE_SOURCE_DIR}/source/desk_up_window_backend)
-
-
-target_include_directories(desk_up_x11_library PUBLIC ${X11_INCLUDE_DIR})
-target_link_libraries(desk_up_x11_library PUBLIC ${X11_LIBRARIES})
+# target_include_directories(desk_up_x11_library PUBLIC ${CMAKE_SOURCE_DIR}/source/desk_up_window_backend)
 
 
+# target_include_directories(desk_up_x11_library PUBLIC ${X11_INCLUDE_DIR})
+# target_link_libraries(desk_up_x11_library PUBLIC ${X11_LIBRARIES})
 
-target_sources(desk_up_x11_library PUBLIC ${CMAKE_CURRENT_LIST_DIR}/desk_up_x11.cc ${CMAKE_SOURCE_DIR}/desk_up_x11.h)
+# target_include_directories(desk_up_x11_library PUBLIC ${CMAKE_SOURCE_DIR}/source/desk_up_window_backend/windowDesc)
+# target_link_libraries(desk_up_x11_library PUBLIC window_desc_library)
+
+# target_sources(desk_up_x11_library PUBLIC ${CMAKE_CURRENT_LIST_DIR}/desk_up_x11.cc ${CMAKE_CURRENT_LIST_DIR}/desk_up_x11.h)

--- a/source/desk_up_window_backend/window_backends/desk_up_x11/desk_up_x11.cc
+++ b/source/desk_up_window_backend/window_backends/desk_up_x11/desk_up_x11.cc
@@ -4,7 +4,7 @@
 #include <unistd.h>
 #include <string>
 
-bool X11_isAvailable(DU_WindowDevice * device){
+bool X11_isAvailable(DU_windowDevice * device){
     
     if(!device) return false;
     
@@ -38,9 +38,9 @@ void X11_DisplayFatalMessage(Display *, void *){
     return;
 }
 
-DU_WindowDevice * X11_CreateDevice(void){
+DU_windowDevice * X11_createDevice(void){
 
-    DU_WindowDevice * device = nullptr;
+    DU_windowDevice * device = nullptr;
     
     device->getWindowHeight = X11_getWindowHeight;
     device->isAvailable = X11_isAvailable;
@@ -73,7 +73,7 @@ DU_WindowDevice * X11_CreateDevice(void){
 }
 
 
-unsigned int X11_getWindowHeight(DU_WindowDevice * _this){
+unsigned int X11_getWindowHeight(DU_windowDevice * _this){
 
     windowData * data = (windowData *) _this->internalData;
 
@@ -93,7 +93,7 @@ unsigned int X11_getWindowHeight(DU_WindowDevice * _this){
     return height;
 }
 
-unsigned int X11_getWindowWidth(DU_WindowDevice * _this){
+unsigned int X11_getWindowWidth(DU_windowDevice * _this){
 
     windowData * data = (windowData *) _this->internalData;
 
@@ -113,7 +113,7 @@ unsigned int X11_getWindowWidth(DU_WindowDevice * _this){
     return width;
 }
 
-unsigned int X11_getWindowXPos(DU_WindowDevice * _this){
+unsigned int X11_getWindowXPos(DU_windowDevice * _this){
 
     windowData * data = (windowData *) _this->internalData;
 
@@ -133,7 +133,7 @@ unsigned int X11_getWindowXPos(DU_WindowDevice * _this){
     return x;
 }
 
-unsigned int X11_getWindowYPos(DU_WindowDevice * _this){
+unsigned int X11_getWindowYPos(DU_windowDevice * _this){
 
     windowData * data = (windowData *) _this->internalData;
 
@@ -153,7 +153,7 @@ unsigned int X11_getWindowYPos(DU_WindowDevice * _this){
     return y;
 }
 
-char * X11_getPathFromWindow(DU_WindowDevice * _this){
+char * X11_getPathFromWindow(DU_windowDevice * _this){
     
     windowData * data = (windowData *)_this->internalData;
 
@@ -210,7 +210,7 @@ char * X11_getPathFromWindow(DU_WindowDevice * _this){
     return buff;
 }
 
-windowDesc X11_getWindowDescFromWindow(DU_WindowDevice * _this){
+windowDesc X11_getWindowDescFromWindow(DU_windowDevice * _this){
     windowDesc newWindow;
 
     try{
@@ -230,7 +230,7 @@ windowDesc X11_getWindowDescFromWindow(DU_WindowDevice * _this){
     return newWindow;
 }
 
-std::vector<windowDesc> X11_getAllWindows(DU_WindowDevice * _this){
+std::vector<windowDesc> X11_getAllWindows(DU_windowDevice * _this){
 
     windowData * data = ((windowData *)_this->internalData);
 

--- a/source/desk_up_window_backend/window_backends/desk_up_x11/desk_up_x11.h
+++ b/source/desk_up_window_backend/window_backends/desk_up_x11/desk_up_x11.h
@@ -2,6 +2,7 @@
 #define DESKUPX11_H
 
 #include <X11/Xlib.h>
+#include <X11/Xatom.h>
 #include <vector>
 #include <stdexcept>
 #include <iostream>
@@ -25,7 +26,6 @@ DU_WindowBootStrap x11WindowDevice = {
 
 
 DU_windowDevice * X11_createDevice(void);
-bool X11_isAvailable(DU_windowDevice * device);
 
 int X11_errorHandlerNonFatal(Display * display, XErrorEvent * event);
 

--- a/source/desk_up_window_backend/window_backends/desk_up_x11/desk_up_x11.h
+++ b/source/desk_up_window_backend/window_backends/desk_up_x11/desk_up_x11.h
@@ -20,21 +20,21 @@ typedef struct windowData{
 
 DU_WindowBootStrap x11WindowDevice = {
     "x11",
-    X11_CreateDevice
+    X11_createDevice
 };
 
 
-DU_WindowDevice * X11_CreateDevice(void);
-bool X11_isAvailable(DU_WindowDevice * device);
+DU_windowDevice * X11_createDevice(void);
+bool X11_isAvailable(DU_windowDevice * device);
 
 int X11_errorHandlerNonFatal(Display * display, XErrorEvent * event);
 
-unsigned int X11_getWindowHeight(DU_WindowDevice * _this);
-unsigned int X11_getWindowWidth(DU_WindowDevice * _this);
-unsigned int X11_getWindowXPos(DU_WindowDevice * _this);
-unsigned int X11_getWindowYPos(DU_WindowDevice * _this);
+unsigned int X11_getWindowHeight(DU_windowDevice * _this);
+unsigned int X11_getWindowWidth(DU_windowDevice * _this);
+unsigned int X11_getWindowXPos(DU_windowDevice * _this);
+unsigned int X11_getWindowYPos(DU_windowDevice * _this);
 
-std::vector<windowDesc> X11_getAllWindows(DU_WindowDevice * _this);
+std::vector<windowDesc> X11_getAllWindows(DU_windowDevice * _this);
 
 
 #endif

--- a/source/desk_up_window_backend/window_global.cc
+++ b/source/desk_up_window_backend/window_global.cc
@@ -1,0 +1,55 @@
+#include "window_global.h"
+
+std::string DESKUPDIR;
+
+struct DU_isAvailable{
+    const char * name;
+    bool (*isAvailable)(void);
+};
+
+bool WIN_isAvailable(){
+    #ifdef _WIN32
+        return true;
+    #endif
+    
+    return false;
+}
+
+
+DU_isAvailable win = {
+    "win",
+    WIN_isAvailable
+};
+
+DU_windowDevice * current_window_backend = nullptr;
+
+HWND desk_up_hwnd = nullptr;
+
+//function to initialize the backend and choose the correct device. Previously used x11 and Windows, but now only connects windows
+int DU_Init(HWND thisHwnd){
+
+    if(thisHwnd){
+        desk_up_hwnd = thisHwnd;
+    }
+
+    const char * devName = win.name;
+    if(!win.isAvailable()){
+        std::cout << devName << " is not an available backend on this system: Exiting" << std::endl;
+        return 0;
+    }
+    
+    DU_windowDevice * dev = winWindowDevice.createDevice();
+
+    if(dev == nullptr){
+        return 0;
+    }
+
+    DESKUPDIR = dev->getDeskUpPath();
+
+    std::cout << "DeskUp path: " << DESKUPDIR << std::endl; 
+
+    current_window_backend = dev;
+    std::cout << devName << " successfully connected as a backend!" << std::endl;
+    
+    return 1;
+}

--- a/source/desk_up_window_backend/window_global.cc
+++ b/source/desk_up_window_backend/window_global.cc
@@ -23,14 +23,9 @@ DU_isAvailable win = {
 
 DU_windowDevice * current_window_backend = nullptr;
 
-HWND desk_up_hwnd = nullptr;
 
 //function to initialize the backend and choose the correct device. Previously used x11 and Windows, but now only connects windows
 int DU_Init(HWND thisHwnd){
-
-    if(thisHwnd){
-        desk_up_hwnd = thisHwnd;
-    }
 
     const char * devName = win.name;
     if(!win.isAvailable()){
@@ -38,7 +33,11 @@ int DU_Init(HWND thisHwnd){
         return 0;
     }
     
-    DU_windowDevice * dev = winWindowDevice.createDevice();
+    HWND h = nullptr;
+    if(thisHwnd){
+        h = thisHwnd;
+    }
+    DU_windowDevice * dev = winWindowDevice.createDevice(h);
 
     if(dev == nullptr){
         return 0;

--- a/source/desk_up_window_backend/window_global.h
+++ b/source/desk_up_window_backend/window_global.h
@@ -2,22 +2,29 @@
 #define WINDOWGLOBAL_H
 
 #include <iostream>
+#include <vector>
+#include "windowDesc.h"
 
-typedef struct DU_WindowDevice{
+typedef struct DU_windowDevice{
     //here goes all the generic functions that all the backends have
-    unsigned int (*getWindowHeight)(DU_WindowDevice * _this);
-    bool (*isAvailable)(DU_WindowDevice * _this);
+    unsigned int (*getWindowHeight)(DU_windowDevice * _this);
+    unsigned int (*getWindowWidth)(DU_windowDevice * _this);
+    unsigned int (*getWindowXPos)(DU_windowDevice * _this);
+    unsigned int (*getWindowYPos)(DU_windowDevice * _this);
+    
+    std::vector<windowDesc> (*getAllWindows)(void);
 
+    bool (*isAvailable)(DU_windowDevice * _this);
 
     void * internalData;
 };
 
 typedef struct DU_WindowBootStrap{
     const char * name;
-    DU_WindowDevice *(*createDevice)(void);
+    DU_windowDevice *(*createDevice)(void);
 };
 
-DU_WindowDevice * current_window_backend;
+DU_windowDevice * current_window_backend;
 
 extern DU_WindowBootStrap x11WindowDevice;
 extern DU_WindowBootStrap winWindowDevice;
@@ -32,7 +39,7 @@ const unsigned int allWindowBootStrapsLength = 2;
 //function to initialize the backend and choose the correct device
 int DU_Init(){
     for(unsigned int i = 0; i < allWindowBootStrapsLength; i++){
-        DU_WindowDevice * dev = allWindowBootStraps[i].createDevice();
+        DU_windowDevice * dev = allWindowBootStraps[i].createDevice();
         const char * devName = allWindowBootStraps[i].name;
 
         if(!dev || !dev->isAvailable(dev)){

--- a/source/desk_up_window_backend/window_global.h
+++ b/source/desk_up_window_backend/window_global.h
@@ -5,65 +5,22 @@
 #include <vector>
 #include "windowDesc.h"
 #include "desk_up_win.h"
+#include "desk_up_window_device.h"
+#include "desk_up_window_bootstrap.h"
 
-const char * DESKUPDIR = "";
+extern std::string DESKUPDIR;
 
-typedef struct DU_windowDevice{
-    //here goes all the generic functions that all the backends have
-    unsigned int (*getWindowHeight)(DU_windowDevice * _this);
-    unsigned int (*getWindowWidth)(DU_windowDevice * _this);
-    unsigned int (*getWindowXPos)(DU_windowDevice * _this);
-    unsigned int (*getWindowYPos)(DU_windowDevice * _this);
-    
-    std::vector<windowDesc> (*getAllWindows)(DU_windowDevice * _this);
+struct DU_isAvailable;
 
-    void * internalData;
-};
+bool WIN_isAvailable();
 
-typedef struct DU_isAvailable{
-    const char * name;
-    bool (*isAvailable)(void);
-};
+extern DU_isAvailable win;
 
-bool WIN_isAvailable(){
-    #ifdef _WIN32
-        return true;
-    #endif
-    
-    return false;
-}
+extern DU_windowDevice * current_window_backend;
 
-
-DU_isAvailable win = {
-    "win",
-    WIN_isAvailable
-};
-
-typedef struct DU_WindowBootStrap{
-    const char * name;
-    DU_windowDevice *(*createDevice)(void);
-};
-
-DU_windowDevice * current_window_backend;
-
-extern DU_WindowBootStrap winWindowDevice;
+extern HWND desk_up_hwnd;
 
 //function to initialize the backend and choose the correct device. Previously used x11 and Windows, but now only connects windows
-int DU_Init(){
-        
-    const char * devName = win.name;
-    if(!win.isAvailable()){
-        std::cout << devName << "is not an available backend on this system: Exiting" << std::endl;
-        return 0;
-    }
-    
-    DU_windowDevice * dev = winWindowDevice.createDevice();
-
-    current_window_backend = dev;
-    std::cout << devName << "successfully connected as a backend!" << std::endl;
-    
-    return 1;
-}
-
+int DU_Init(HWND thisHwnd);
 
 #endif


### PR DESCRIPTION
# Save workspaces
In this branch, I've implemented saving a workspace in the local computer of the user. All visible windows get saved inside a text file which has the same name as the executable of the app(```spotify.exe``` will get saved as ```spotify.txt```), and all of the workspace gets saved inside ```C:\Users\user\Roaming\DeskUp\workspaceName```. 

Notes:
- This feature still needs some *__code cleanup__*, *__documentation__* and *__minor fixes__* (sometimes *DeskUp* saves apps that are not visible, probably because some of the visible apps use them as a backbone for their app). 
- When adding a workspace whose name is already used, files get overwritten. A message alerting the user if he wants to overwrite would be nice. 
- I've used the already implemented Windows backend functions (WIN_*), and added some private ones to easen the chore, all inside ```source/desk_up_window_backend/window_backends/desk_up_win```. 

# Linux Compatibility
Compatibility with Linux (X11) has been dropped, explained in 0d4f0e8365093c4e0209b28f63a98d30853c7da2