### PR TITLE
Chore/clean backend

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -156,7 +156,7 @@ if it is not given the correct permissions
 
 [X] cleanup, show messages in the frontend
 
-[/] Restructure the project: create a library for each component, and create a correct namespace for each part of the project (DeskUp:: for globals, then create namespaces inside namespaces...)
+[/] Restructure the project: create a library for each component, and create a correct namespace for each part of the project (DeskUp:: for globals, then create namespaces inside namespaces...). Also refactor the functions of the backend to take fs::path instead of std::string
 
 [X] (optional for this task) mingw gets saved as the default bash terminal, fix it
 

--- a/TODO.md
+++ b/TODO.md
@@ -145,7 +145,10 @@ including the qt dlls.
 
 [X] Create a dummy device which is used to check the deskUp backend. Note that it does not check the window device, but rather the structure associated with deskUp. Tests for each windowDevice function, with things like empty paths, negative dimensions, non valid pats... Try also looking into testing the device itself, specially windows.
 
-[] Refactor the workflow of the backend operations. Make sure the errors are significant and that the functions d not fail unless there is a real error. Operations that retry should reflect it, consistency in param checking... With these changes, the already created tests should also be changed to reflect these changes, and they should adjust to the contracts of each function
+[] (optional for this task) Refactor the workflow of the backend operations. Make sure the errors are significant and that the functions d not fail unless there is a real error. Operations that retry should reflect it, consistency in param checking... With these changes, the already created tests should also be changed to reflect these changes, and they should adjust to the contracts of each function
+
+[] (optional for this task) when deskup starts, check the privileges it was given, and show a message warning saying that deskup may not work properly
+if it is not given the correct permissions
 
 ## 7. Create DeskUp Error system
 

--- a/TODO.md
+++ b/TODO.md
@@ -145,7 +145,7 @@ including the qt dlls.
 
 [X] Create a dummy device which is used to check the deskUp backend. Note that it does not check the window device, but rather the structure associated with deskUp. Tests for each windowDevice function, with things like empty paths, negative dimensions, non valid pats... Try also looking into testing the device itself, specially windows.
 
-[/] (optional for this task) Refactor the workflow of the backend operations. Make sure the errors are significant and that the functions d not fail unless there is a real error. Operations that retry should reflect it, consistency in param checking... With these changes, the already created tests should also be changed to reflect these changes, and they should adjust to the contracts of each function. It is important that the caller functions (generally the DeskUpBackendInterface::*) treat ALL of the errors that the backend specific functions can return.
+[X] (optional for this task) Refactor the workflow of the backend operations. Make sure the errors are significant and that the functions d not fail unless there is a real error. Operations that retry should reflect it, consistency in param checking... With these changes, the already created tests should also be changed to reflect these changes, and they should adjust to the contracts of each function. It is important that the caller functions (generally the DeskUpBackendInterface::*) treat ALL of the errors that the backend specific functions can return.
 
 [] (optional for this task) when deskup starts, check the privileges it was given, and show a message warning saying that deskup may not work properly
 if it is not given the correct permissions

--- a/TODO.md
+++ b/TODO.md
@@ -145,7 +145,7 @@ including the qt dlls.
 
 [X] Create a dummy device which is used to check the deskUp backend. Note that it does not check the window device, but rather the structure associated with deskUp. Tests for each windowDevice function, with things like empty paths, negative dimensions, non valid pats... Try also looking into testing the device itself, specially windows.
 
-[] (optional for this task) Refactor the workflow of the backend operations. Make sure the errors are significant and that the functions d not fail unless there is a real error. Operations that retry should reflect it, consistency in param checking... With these changes, the already created tests should also be changed to reflect these changes, and they should adjust to the contracts of each function
+[/] (optional for this task) Refactor the workflow of the backend operations. Make sure the errors are significant and that the functions d not fail unless there is a real error. Operations that retry should reflect it, consistency in param checking... With these changes, the already created tests should also be changed to reflect these changes, and they should adjust to the contracts of each function. It is important that the caller functions (generally the DeskUpBackendInterface::*) treat ALL of the errors that the backend specific functions can return.
 
 [] (optional for this task) when deskup starts, check the privileges it was given, and show a message warning saying that deskup may not work properly
 if it is not given the correct permissions

--- a/benchmark/desk_up_backend_interface_benchmark/desk_up_backend_interface_benchmark.cc
+++ b/benchmark/desk_up_backend_interface_benchmark/desk_up_backend_interface_benchmark.cc
@@ -1,12 +1,150 @@
 #include <benchmark/benchmark.h>
 
 #include "desk_up_backend_interface.h"
+#include "window_core.h"
+#include <filesystem>
+#include <string>
 
-static void BM_DeskUpBackendInterface(benchmark::State& state) {
-  for (auto _ : state){
-    int i = 0;
-    i = state.max_iterations;
-  }
+namespace fs = std::filesystem;
+
+// Benchmark workspace name validation
+static void BM_IsWorkspaceValid(benchmark::State& state) {
+    std::string validName = "MyWorkspace";
+    std::string invalidName = "Invalid:Name*";
+    
+    for (auto _ : state) {
+        bool result1 = DeskUpBackendInterface::isWorkspaceValid(validName);
+        bool result2 = DeskUpBackendInterface::isWorkspaceValid(invalidName);
+        benchmark::DoNotOptimize(result1);
+        benchmark::DoNotOptimize(result2);
+    }
 }
 
-BENCHMARK(BM_DeskUpBackendInterface);
+// Benchmark checking if workspace exists
+static void BM_ExistsWorkspace(benchmark::State& state) {
+    DU_Init();
+    std::string workspaceName = "BenchmarkWorkspace";
+    
+    for (auto _ : state) {
+        bool result = DeskUpBackendInterface::existsWorkspace(workspaceName);
+        benchmark::DoNotOptimize(result);
+    }
+
+    DU_Destroy();
+}
+
+// Benchmark checking if file exists
+static void BM_ExistsFile(benchmark::State& state) {
+    DU_Init();
+    fs::path testPath = fs::temp_directory_path() / "benchmark_test.txt";
+    
+    for (auto _ : state) {
+        bool result = DeskUpBackendInterface::existsFile(testPath);
+        benchmark::DoNotOptimize(result);
+    }
+
+    DU_Destroy();
+}
+
+// Benchmark saving all windows (end-to-end)
+static void BM_SaveAllWindowsLocal(benchmark::State& state) {
+    DU_Init();
+    std::string workspaceName = "BenchmarkSaveWorkspace";
+    
+    // Clean up before benchmarking
+    DeskUpBackendInterface::removeWorkspace(workspaceName);
+    
+    for (auto _ : state) {
+        state.PauseTiming();
+        DeskUpBackendInterface::removeWorkspace(workspaceName);
+        state.ResumeTiming();
+        
+        auto result = DeskUpBackendInterface::saveAllWindowsLocal(workspaceName);
+        benchmark::DoNotOptimize(result);
+        benchmark::ClobberMemory();
+    }
+    
+    // Clean up after benchmark
+    DeskUpBackendInterface::removeWorkspace(workspaceName);
+    DU_Destroy();
+}
+
+// Benchmark restoring windows (end-to-end)
+static void BM_RestoreWindows(benchmark::State& state) {
+    DU_Init();
+    std::string workspaceName = "BenchmarkRestoreWorkspace";
+    
+    // Setup: save current state
+    DeskUpBackendInterface::removeWorkspace(workspaceName);
+    auto saveResult = DeskUpBackendInterface::saveAllWindowsLocal(workspaceName);
+    
+    if (!saveResult) {
+        state.SkipWithError("Failed to create workspace for restore benchmark");
+        DU_Destroy();
+        return;
+    }
+    
+    for (auto _ : state) {
+        auto result = DeskUpBackendInterface::restoreWindows(workspaceName);
+        benchmark::DoNotOptimize(result);
+        benchmark::ClobberMemory();
+    }
+    
+    // Clean up
+    DeskUpBackendInterface::removeWorkspace(workspaceName);
+    DU_Destroy();
+}
+
+// Benchmark workspace removal
+static void BM_RemoveWorkspace(benchmark::State& state) {
+    DU_Init();
+    std::string workspaceName = "BenchmarkRemoveWorkspace";
+    
+    for (auto _ : state) {
+        state.PauseTiming();
+        // Create workspace before each iteration
+        DeskUpBackendInterface::saveAllWindowsLocal(workspaceName);
+        state.ResumeTiming();
+        
+        int result = DeskUpBackendInterface::removeWorkspace(workspaceName);
+        benchmark::DoNotOptimize(result);
+    }
+
+    DU_Destroy();
+}
+
+// Benchmark complete save-restore-remove cycle
+static void BM_CompleteWorkspaceCycle(benchmark::State& state) {
+    DU_Init();
+    std::string workspaceName = "BenchmarkCycleWorkspace";
+    
+    for (auto _ : state) {
+        // Save
+        auto saveResult = DeskUpBackendInterface::saveAllWindowsLocal(workspaceName);
+        benchmark::DoNotOptimize(saveResult);
+        
+        // Check existence
+        bool exists = DeskUpBackendInterface::existsWorkspace(workspaceName);
+        benchmark::DoNotOptimize(exists);
+        
+        // Restore
+        auto restoreResult = DeskUpBackendInterface::restoreWindows(workspaceName);
+        benchmark::DoNotOptimize(restoreResult);
+        
+        // Remove
+        int removeResult = DeskUpBackendInterface::removeWorkspace(workspaceName);
+        benchmark::DoNotOptimize(removeResult);
+        
+        benchmark::ClobberMemory();
+    }
+
+    DU_Destroy();
+}
+
+BENCHMARK(BM_IsWorkspaceValid);
+BENCHMARK(BM_ExistsWorkspace);
+BENCHMARK(BM_ExistsFile);
+BENCHMARK(BM_SaveAllWindowsLocal);
+BENCHMARK(BM_RestoreWindows);
+BENCHMARK(BM_RemoveWorkspace);
+BENCHMARK(BM_CompleteWorkspaceCycle);

--- a/benchmark/desk_up_error_benchmark/desk_up_error_benchmark.cc
+++ b/benchmark/desk_up_error_benchmark/desk_up_error_benchmark.cc
@@ -1,12 +1,187 @@
 #include <benchmark/benchmark.h>
 
 #include "desk_up_error.h"
+#ifdef _WIN32
+    #include <Windows.h>
+#endif
 
-static void BM_DeskUpError(benchmark::State& state) {
-  for (auto _ : state){
-    int i = 0;
-    i = state.max_iterations;
-  }
+// Benchmark error construction
+static void BM_ErrorConstruction(benchmark::State& state) {
+    for (auto _ : state) {
+        DeskUp::Error err(DeskUp::Level::Error, DeskUp::ErrType::InvalidInput, 0, "Test error message");
+        benchmark::DoNotOptimize(err);
+    }
 }
 
-BENCHMARK(BM_DeskUpError);
+// Benchmark error construction with move semantics
+static void BM_ErrorConstructionMove(benchmark::State& state) {
+    for (auto _ : state) {
+        std::string msg = "Test error message with longer content for move semantics";
+        DeskUp::Error err(DeskUp::Level::Fatal, DeskUp::ErrType::AccessDenied, 3, std::move(msg));
+        benchmark::DoNotOptimize(err);
+    }
+}
+
+// Benchmark error level checking
+static void BM_ErrorLevelChecking(benchmark::State& state) {
+    DeskUp::Error err(DeskUp::Level::Retry, DeskUp::ErrType::Io, 2, "Retry error");
+
+    for (auto _ : state) {
+        bool isFatal = err.isFatal();
+        bool isRetryable = err.isRetryable();
+        bool isSkippable = err.isSkippable();
+        bool isWarning = err.isWarning();
+        bool isError = err.isError();
+
+        benchmark::DoNotOptimize(isFatal);
+        benchmark::DoNotOptimize(isRetryable);
+        benchmark::DoNotOptimize(isSkippable);
+        benchmark::DoNotOptimize(isWarning);
+        benchmark::DoNotOptimize(isError);
+    }
+}
+
+// Benchmark error property access
+static void BM_ErrorPropertyAccess(benchmark::State& state) {
+    DeskUp::Error err(DeskUp::Level::Warning, DeskUp::ErrType::NotFound, 1, "Warning message");
+
+    for (auto _ : state) {
+        auto level = err.level();
+        auto type = err.type();
+        auto attempts = err.attempts();
+        auto msg = err.what();
+
+        benchmark::DoNotOptimize(level);
+        benchmark::DoNotOptimize(type);
+        benchmark::DoNotOptimize(attempts);
+        benchmark::DoNotOptimize(msg);
+    }
+}
+
+#ifdef _WIN32
+// Benchmark Windows error code conversion
+static void BM_FromLastWinError(benchmark::State& state) {
+    for (auto _ : state) {
+        SetLastError(ERROR_ACCESS_DENIED);
+        auto err = DeskUp::Error::fromLastWinError("BM_FromLastWinError|test");
+        benchmark::DoNotOptimize(err);
+    }
+}
+
+// Benchmark Windows error with explicit code
+static void BM_FromWinErrorCode(benchmark::State& state) {
+    for (auto _ : state) {
+        auto err = DeskUp::Error::fromLastWinError(ERROR_FILE_NOT_FOUND, "BM_FromWinErrorCode|test", 2);
+        benchmark::DoNotOptimize(err);
+    }
+}
+
+// Benchmark various Windows error codes
+static void BM_FromWinErrorVariousCodes(benchmark::State& state) {
+    DWORD codes[] = {
+        ERROR_ACCESS_DENIED,
+        ERROR_FILE_NOT_FOUND,
+        ERROR_NOT_ENOUGH_MEMORY,
+        ERROR_SHARING_VIOLATION,
+        ERROR_DISK_FULL,
+        ERROR_INVALID_HANDLE
+    };
+
+    size_t idx = 0;
+    for (auto _ : state) {
+        auto err = DeskUp::Error::fromLastWinError(codes[idx % 6], "BM_FromWinErrorVariousCodes|test");
+        benchmark::DoNotOptimize(err);
+        idx++;
+    }
+}
+#endif
+
+// Benchmark save error conversion
+static void BM_FromSaveError(benchmark::State& state) {
+    for (auto _ : state) {
+        auto err = DeskUp::Error::fromSaveError(-3); // ERR_NO_PERMISSION
+        benchmark::DoNotOptimize(err);
+    }
+}
+
+// Benchmark save error various codes
+static void BM_FromSaveErrorVariousCodes(benchmark::State& state) {
+    int codes[] = { 1, -1, -2, -3, -4, -5, -6 };
+    size_t idx = 0;
+
+    for (auto _ : state) {
+        auto err = DeskUp::Error::fromSaveError(codes[idx % 7]);
+        benchmark::DoNotOptimize(err);
+        idx++;
+    }
+}
+
+// Benchmark Result<T> success path
+static void BM_ResultSuccess(benchmark::State& state) {
+    for (auto _ : state) {
+        DeskUp::Result<int> result = 42;
+        benchmark::DoNotOptimize(result);
+
+        if (result.has_value()) {
+            int value = result.value();
+            benchmark::DoNotOptimize(value);
+        }
+    }
+}
+
+// Benchmark Result<T> error path
+static void BM_ResultError(benchmark::State& state) {
+    for (auto _ : state) {
+        DeskUp::Result<int> result = std::unexpected(
+            DeskUp::Error(DeskUp::Level::Error, DeskUp::ErrType::NotFound, 0, "Not found")
+        );
+        benchmark::DoNotOptimize(result);
+
+        if (!result.has_value()) {
+            auto err = result.error();
+            benchmark::DoNotOptimize(err);
+        }
+    }
+}
+
+// Benchmark Status success
+static void BM_StatusSuccess(benchmark::State& state) {
+    for (auto _ : state) {
+        DeskUp::Status status{};
+        benchmark::DoNotOptimize(status);
+
+        bool success = status.has_value();
+        benchmark::DoNotOptimize(success);
+    }
+}
+
+// Benchmark Status error
+static void BM_StatusError(benchmark::State& state) {
+    for (auto _ : state) {
+        DeskUp::Status status = std::unexpected(
+            DeskUp::Error(DeskUp::Level::Fatal, DeskUp::ErrType::Io, 3, "IO error")
+        );
+        benchmark::DoNotOptimize(status);
+
+        if (!status.has_value()) {
+            auto err = status.error();
+            benchmark::DoNotOptimize(err);
+        }
+    }
+}
+
+BENCHMARK(BM_ErrorConstruction);
+BENCHMARK(BM_ErrorConstructionMove);
+BENCHMARK(BM_ErrorLevelChecking);
+BENCHMARK(BM_ErrorPropertyAccess);
+#ifdef _WIN32
+BENCHMARK(BM_FromLastWinError);
+BENCHMARK(BM_FromWinErrorCode);
+BENCHMARK(BM_FromWinErrorVariousCodes);
+#endif
+BENCHMARK(BM_FromSaveError);
+BENCHMARK(BM_FromSaveErrorVariousCodes);
+BENCHMARK(BM_ResultSuccess);
+BENCHMARK(BM_ResultError);
+BENCHMARK(BM_StatusSuccess);
+BENCHMARK(BM_StatusError);

--- a/benchmark/desk_up_error_gui_converter_benchmark/desk_up_error_gui_converter_benchmark.cc
+++ b/benchmark/desk_up_error_gui_converter_benchmark/desk_up_error_gui_converter_benchmark.cc
@@ -1,12 +1,129 @@
 #include <benchmark/benchmark.h>
 
 #include "desk_up_error_gui_converter.h"
+#include "desk_up_error.h"
 
-static void BM_DeskUpErrorGuiConverter(benchmark::State& state) {
-  for (auto _ : state){
-    int i = 0;
-    i = state.max_iterations;
-  }
+using namespace DeskUp;
+using namespace DeskUp::UI;
+
+// Benchmark error level mapping
+static void BM_MapLevel(benchmark::State& state) {
+    for (auto _ : state) {
+        auto result1 = ErrorAdapter::mapLevel(Level::Fatal);
+        auto result2 = ErrorAdapter::mapLevel(Level::Error);
+        auto result3 = ErrorAdapter::mapLevel(Level::Warning);
+        auto result4 = ErrorAdapter::mapLevel(Level::Retry);
+        auto result5 = ErrorAdapter::mapLevel(Level::Info);
+
+        benchmark::DoNotOptimize(result1);
+        benchmark::DoNotOptimize(result2);
+        benchmark::DoNotOptimize(result3);
+        benchmark::DoNotOptimize(result4);
+        benchmark::DoNotOptimize(result5);
+    }
 }
 
-BENCHMARK(BM_DeskUpErrorGuiConverter);
+// Benchmark getting user message
+static void BM_GetUserMessage(benchmark::State& state) {
+    Error err(Level::Error, ErrType::AccessDenied, 2, "Access denied error");
+
+    for (auto _ : state) {
+        QString msg = ErrorAdapter::getUserMessage(err);
+        benchmark::DoNotOptimize(msg);
+    }
+}
+
+// Benchmark getting user message for various error types
+static void BM_GetUserMessageVariousTypes(benchmark::State& state) {
+    std::vector<Error> errors = {
+        Error(Level::Fatal, ErrType::InsufficientMemory, 0, "Out of memory"),
+        Error(Level::Error, ErrType::FileNotFound, 1, "File not found"),
+        Error(Level::Warning, ErrType::Timeout, 2, "Operation timed out"),
+        Error(Level::Retry, ErrType::NetworkError, 3, "Network error"),
+        Error(Level::Info, ErrType::None, 0, "Info message"),
+        Error(Level::Skip, ErrType::InvalidInput, 1, "Invalid input")
+    };
+
+    size_t idx = 0;
+    for (auto _ : state) {
+        QString msg = ErrorAdapter::getUserMessage(errors[idx % errors.size()]);
+        benchmark::DoNotOptimize(msg);
+        idx++;
+    }
+}
+
+// Benchmark complete error to message conversion
+static void BM_ErrorToMessageConversion(benchmark::State& state) {
+    for (auto _ : state) {
+        Error err(Level::Warning, ErrType::DiskFull, 1, "Disk is full");
+
+        QString msg = ErrorAdapter::getUserMessage(err);
+        auto level = ErrorAdapter::mapLevel(err.level());
+
+        benchmark::DoNotOptimize(msg);
+        benchmark::DoNotOptimize(level);
+    }
+}
+
+// Benchmark QString creation from std::string
+static void BM_QStringConversion(benchmark::State& state) {
+    Error err(Level::Error, ErrType::CorruptedData, 0, "Corrupted data detected");
+
+    for (auto _ : state) {
+        QString msg = QString::fromUtf8(err.what());
+        benchmark::DoNotOptimize(msg);
+    }
+}
+
+// Benchmark mapping all error levels
+static void BM_MapAllLevels(benchmark::State& state) {
+    std::vector<Level> levels = {
+        Level::Fatal,
+        Level::Error,
+        Level::Warning,
+        Level::Retry,
+        Level::Info,
+        Level::Debug,
+        Level::Default,
+        Level::Skip,
+        Level::None
+    };
+
+    size_t idx = 0;
+    for (auto _ : state) {
+        auto result = ErrorAdapter::mapLevel(levels[idx % levels.size()]);
+        benchmark::DoNotOptimize(result);
+        idx++;
+    }
+}
+
+// Benchmark batch error message generation
+static void BM_BatchErrorMessages(benchmark::State& state) {
+    std::vector<Error> errors;
+    errors.reserve(10);
+
+    for (int i = 0; i < 10; ++i) {
+        errors.emplace_back(
+            static_cast<Level>(i % 9),
+            static_cast<ErrType>(i % 15),
+            i,
+            "Batch error message " + std::to_string(i)
+        );
+    }
+
+    for (auto _ : state) {
+        for (const auto& err : errors) {
+            QString msg = ErrorAdapter::getUserMessage(err);
+            benchmark::DoNotOptimize(msg);
+        }
+        benchmark::ClobberMemory();
+    }
+}
+
+BENCHMARK(BM_MapLevel);
+BENCHMARK(BM_GetUserMessage);
+BENCHMARK(BM_GetUserMessageVariousTypes);
+BENCHMARK(BM_ErrorToMessageConversion);
+BENCHMARK(BM_QStringConversion);
+BENCHMARK(BM_MapAllLevels);
+BENCHMARK(BM_BatchErrorMessages);

--- a/benchmark/desk_up_frontend_benchmark/desk_up_frontend_benchmark.cc
+++ b/benchmark/desk_up_frontend_benchmark/desk_up_frontend_benchmark.cc
@@ -1,12 +1,180 @@
 #include <benchmark/benchmark.h>
 
 #include "mainWindow.h"
+#include "desk_up_backend_interface.h"
+#include "window_core.h"
+#include <QApplication>
+#include <QTimer>
 
-static void BM_DeskUpFrontend(benchmark::State& state) {
-  for (auto _ : state){
-    int i = 0;
-    i = state.max_iterations;
-  }
+// Note: GUI benchmarks are tricky because Qt requires an event loop.
+// These benchmarks focus on non-GUI aspects and simulated operations.
+
+// Benchmark MainWindow construction
+static void BM_MainWindowConstruction(benchmark::State& state) {
+    int argc = 0;
+    char* argv[] = { nullptr };
+    QApplication app(argc, argv);
+
+    for (auto _ : state) {
+        MainWindow window;
+        benchmark::DoNotOptimize(window);
+    }
 }
 
-BENCHMARK(BM_DeskUpFrontend);
+// Benchmark workspace name validation (frontend utility)
+static void BM_WorkspaceValidation(benchmark::State& state) {
+    DU_Init();
+
+    std::vector<std::string> workspaceNames = {
+        "ValidWorkspace",
+        "Another_Workspace",
+        "workspace123",
+        "Invalid:Name",
+        "Invalid*Name",
+        "Invalid?Name",
+        ""
+    };
+
+    size_t idx = 0;
+    for (auto _ : state) {
+        bool isValid = DeskUpBackendInterface::isWorkspaceValid(workspaceNames[idx % workspaceNames.size()]);
+        benchmark::DoNotOptimize(isValid);
+        idx++;
+    }
+
+    DU_Destroy();
+}
+
+// Benchmark workspace existence check (common frontend operation)
+static void BM_WorkspaceExistenceCheck(benchmark::State& state) {
+    DU_Init();
+
+    std::vector<std::string> workspaceNames = {
+        "ExistingWorkspace",
+        "NonExistingWorkspace",
+        "AnotherWorkspace"
+    };
+
+    // Create one workspace for testing
+    DeskUpBackendInterface::saveAllWindowsLocal(workspaceNames[0]);
+
+    size_t idx = 0;
+    for (auto _ : state) {
+        bool exists = DeskUpBackendInterface::existsWorkspace(workspaceNames[idx % workspaceNames.size()]);
+        benchmark::DoNotOptimize(exists);
+        idx++;
+    }
+
+    // Clean up
+    DeskUpBackendInterface::removeWorkspace(workspaceNames[0]);
+    DU_Destroy();
+}
+
+// Benchmark simulated save workflow (what happens when user clicks "Save")
+static void BM_SimulatedSaveWorkflow(benchmark::State& state) {
+    DU_Init();
+    std::string workspaceName = "FrontendBenchmarkWorkspace";
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        DeskUpBackendInterface::removeWorkspace(workspaceName);
+        state.ResumeTiming();
+
+        // Validate name
+        bool isValid = DeskUpBackendInterface::isWorkspaceValid(workspaceName);
+        benchmark::DoNotOptimize(isValid);
+
+        if (isValid) {
+            // Save workspace
+            auto result = DeskUpBackendInterface::saveAllWindowsLocal(workspaceName);
+            benchmark::DoNotOptimize(result);
+        }
+
+        benchmark::ClobberMemory();
+    }
+
+    DeskUpBackendInterface::removeWorkspace(workspaceName);
+    DU_Destroy();
+}
+
+// Benchmark simulated restore workflow (what happens when user clicks "Restore")
+static void BM_SimulatedRestoreWorkflow(benchmark::State& state) {
+    DU_Init();
+    std::string workspaceName = "FrontendRestoreBenchmark";
+
+    // Setup: create a workspace to restore
+    DeskUpBackendInterface::removeWorkspace(workspaceName);
+    auto saveResult = DeskUpBackendInterface::saveAllWindowsLocal(workspaceName);
+
+    if (!saveResult) {
+        state.SkipWithError("Failed to create workspace for restore benchmark");
+        DU_Destroy();
+        return;
+    }
+
+    for (auto _ : state) {
+        // Check if workspace exists
+        bool exists = DeskUpBackendInterface::existsWorkspace(workspaceName);
+        benchmark::DoNotOptimize(exists);
+
+        if (exists) {
+            // Restore workspace
+            auto result = DeskUpBackendInterface::restoreWindows(workspaceName);
+            benchmark::DoNotOptimize(result);
+        }
+
+        benchmark::ClobberMemory();
+    }
+
+    DeskUpBackendInterface::removeWorkspace(workspaceName);
+    DU_Destroy();
+}
+
+// Benchmark multiple workspace operations (frontend stress test)
+static void BM_MultipleWorkspaceOperations(benchmark::State& state) {
+    DU_Init();
+
+    std::vector<std::string> workspaceNames = {
+        "Workspace1",
+        "Workspace2",
+        "Workspace3"
+    };
+
+    for (auto _ : state) {
+        // Save multiple workspaces
+        for (const auto& name : workspaceNames) {
+            if (DeskUpBackendInterface::isWorkspaceValid(name)) {
+                auto result = DeskUpBackendInterface::saveAllWindowsLocal(name);
+                benchmark::DoNotOptimize(result);
+            }
+        }
+
+        // Check their existence
+        for (const auto& name : workspaceNames) {
+            bool exists = DeskUpBackendInterface::existsWorkspace(name);
+            benchmark::DoNotOptimize(exists);
+        }
+
+        // Remove them
+        for (const auto& name : workspaceNames) {
+            int removed = DeskUpBackendInterface::removeWorkspace(name);
+            benchmark::DoNotOptimize(removed);
+        }
+
+        benchmark::ClobberMemory();
+    }
+
+    // Cleanup
+    for (const auto& name : workspaceNames) {
+        DeskUpBackendInterface::removeWorkspace(name);
+    }
+
+    DU_Destroy();
+}
+
+BENCHMARK(BM_MainWindowConstruction);
+BENCHMARK(BM_WorkspaceValidation);
+BENCHMARK(BM_WorkspaceExistenceCheck);
+BENCHMARK(BM_SimulatedSaveWorkflow);
+BENCHMARK(BM_SimulatedRestoreWorkflow);
+BENCHMARK(BM_MultipleWorkspaceOperations);

--- a/benchmark/desk_up_window_backend_benchmark/desk_up_window_backend_benchmark.cc
+++ b/benchmark/desk_up_window_backend_benchmark/desk_up_window_backend_benchmark.cc
@@ -1,12 +1,158 @@
 #include <benchmark/benchmark.h>
 
 #include "window_core.h"
+#include "desk_up_window_device.h"
 
-static void BM_DeskUpWindowBackend(benchmark::State& state) {
-    for (auto _ : state){
-        int i = 0;
-        i = state.max_iterations;
+// Benchmark device initialization
+static void BM_CreateWindowDevice(benchmark::State& state) {
+    for (auto _ : state) {
+        DU_Init();
+        benchmark::DoNotOptimize(current_window_backend);
+        DU_Destroy();
     }
 }
 
-BENCHMARK(BM_DeskUpWindowBackend);
+// Benchmark getting window geometry (X position)
+static void BM_GetWindowXPos(benchmark::State& state) {
+    DU_Init();
+    if (!current_window_backend) {
+        state.SkipWithError("Backend not initialized");
+        return;
+    }
+
+    for (auto _ : state) {
+        auto result = current_window_backend->getWindowXPos(current_window_backend.get());
+        benchmark::DoNotOptimize(result);
+    }
+
+    DU_Destroy();
+}
+
+// Benchmark getting window geometry (Y position)
+static void BM_GetWindowYPos(benchmark::State& state) {
+    DU_Init();
+    if (!current_window_backend) {
+        state.SkipWithError("Backend not initialized");
+        return;
+    }
+
+    for (auto _ : state) {
+        auto result = current_window_backend->getWindowYPos(current_window_backend.get());
+        benchmark::DoNotOptimize(result);
+    }
+
+    DU_Destroy();
+}
+
+// Benchmark getting window width
+static void BM_GetWindowWidth(benchmark::State& state) {
+    DU_Init();
+    if (!current_window_backend) {
+        state.SkipWithError("Backend not initialized");
+        return;
+    }
+
+    for (auto _ : state) {
+        auto result = current_window_backend->getWindowWidth(current_window_backend.get());
+        benchmark::DoNotOptimize(result);
+    }
+
+    DU_Destroy();
+}
+
+// Benchmark getting window height
+static void BM_GetWindowHeight(benchmark::State& state) {
+    DU_Init();
+    if (!current_window_backend) {
+        state.SkipWithError("Backend not initialized");
+        return;
+    }
+
+    for (auto _ : state) {
+        auto result = current_window_backend->getWindowHeight(current_window_backend.get());
+        benchmark::DoNotOptimize(result);
+    }
+
+    DU_Destroy();
+}
+
+// Benchmark getting all geometry at once
+static void BM_GetAllWindowGeometry(benchmark::State& state) {
+    DU_Init();
+    if (!current_window_backend) {
+        state.SkipWithError("Backend not initialized");
+        return;
+    }
+
+    for (auto _ : state) {
+        auto x = current_window_backend->getWindowXPos(current_window_backend.get());
+        auto y = current_window_backend->getWindowYPos(current_window_backend.get());
+        auto w = current_window_backend->getWindowWidth(current_window_backend.get());
+        auto h = current_window_backend->getWindowHeight(current_window_backend.get());
+        benchmark::DoNotOptimize(x);
+        benchmark::DoNotOptimize(y);
+        benchmark::DoNotOptimize(w);
+        benchmark::DoNotOptimize(h);
+    }
+
+    DU_Destroy();
+}
+
+// Benchmark getting path from window
+static void BM_GetPathFromWindow(benchmark::State& state) {
+    DU_Init();
+    if (!current_window_backend) {
+        state.SkipWithError("Backend not initialized");
+        return;
+    }
+
+    for (auto _ : state) {
+        auto result = current_window_backend->getPathFromWindow(current_window_backend.get());
+        benchmark::DoNotOptimize(result);
+    }
+
+    DU_Destroy();
+}
+
+// Benchmark enumerating all open windows
+static void BM_GetAllOpenWindows(benchmark::State& state) {
+    DU_Init();
+    if (!current_window_backend) {
+        state.SkipWithError("Backend not initialized");
+        return;
+    }
+
+    for (auto _ : state) {
+        auto result = current_window_backend->getAllOpenWindows(current_window_backend.get());
+        benchmark::DoNotOptimize(result);
+        benchmark::ClobberMemory();
+    }
+
+    DU_Destroy();
+}
+
+// Benchmark getting DeskUp path
+static void BM_GetDeskUpPath(benchmark::State& state) {
+    DU_Init();
+    if (!current_window_backend) {
+        state.SkipWithError("Backend not initialized");
+        return;
+    }
+
+    for (auto _ : state) {
+        auto result = current_window_backend->getDeskUpPath();
+        benchmark::DoNotOptimize(result);
+    }
+
+    DU_Destroy();
+}
+
+BENCHMARK(BM_CreateWindowDevice);
+BENCHMARK(BM_GetWindowXPos);
+BENCHMARK(BM_GetWindowYPos);
+BENCHMARK(BM_GetWindowWidth);
+BENCHMARK(BM_GetWindowHeight);
+BENCHMARK(BM_GetAllWindowGeometry);
+BENCHMARK(BM_GetPathFromWindow);
+BENCHMARK(BM_GetAllOpenWindows);
+BENCHMARK(BM_GetDeskUpPath);

--- a/cmake/win32.cmake
+++ b/cmake/win32.cmake
@@ -1,6 +1,6 @@
 # Unlike other cmake modules, this one just defines the win32 interface library
 
-    # --- Create an interface library representing win32. Any sub-library that uses win32 should link against this one --- 
+    # --- Create an interface library representing win32. Any sub-library that uses win32 should link against this one ---
 
         add_library(desk_up_win32_library INTERFACE)
 
@@ -8,6 +8,7 @@
             WIN32_LEAN_AND_MEAN
             NOMINMAX
             _UNICODE
+    		UNICODE
         )
 
         target_link_libraries(desk_up_win32_library INTERFACE

--- a/source/desk_up_backend_interface/desk_up_backend_interface.cc
+++ b/source/desk_up_backend_interface/desk_up_backend_interface.cc
@@ -82,6 +82,7 @@ DeskUp::Status DeskUpBackendInterface::restoreWindows(std::string workspaceName)
     }
 
     bool forceTermination = true;
+	//check, for each function, what errors it returns, and act in consequence
     for (const auto& file : fs::directory_iterator{p}) {
         auto res = current_window_backend->recoverSavedWindow(current_window_backend.get(), file.path());
         if (!res.has_value() && res.error().isFatal())

--- a/source/desk_up_backend_interface/desk_up_backend_interface.cc
+++ b/source/desk_up_backend_interface/desk_up_backend_interface.cc
@@ -11,11 +11,11 @@
 namespace fs = std::filesystem;
 
 DeskUp::Status DeskUpBackendInterface::saveAllWindowsLocal(std::string workspaceName){
-    
+
     fs::path workspacePath = DESKUPDIR;
     workspacePath /= workspaceName;
     fs::create_directory(workspacePath);
-    
+
     auto windows = current_window_backend.get()->getAllOpenWindows(current_window_backend.get());
 
     if(!windows.has_value()){
@@ -27,7 +27,7 @@ DeskUp::Status DeskUpBackendInterface::saveAllWindowsLocal(std::string workspace
     int id = 0;
 
     for(unsigned int i = 0; i < windows.value().size(); i++){
-        
+
         //create path
         fs::path p(workspacePath);
         p /= windows.value()[i].name;
@@ -35,9 +35,9 @@ DeskUp::Status DeskUpBackendInterface::saveAllWindowsLocal(std::string workspace
         if(existsFile(p)){
             p += std::to_string(id++);
         }
-        
+
         if(int res = windows.value()[i].saveTo(p); res < 0){
-            
+
             auto err = DeskUp::Error::fromSaveError(res);
 
             if(err.isFatal()){
@@ -58,7 +58,7 @@ DeskUp::Status DeskUpBackendInterface::saveAllWindowsLocal(std::string workspace
 }
 
 DeskUp::Status DeskUpBackendInterface::restoreWindows(std::string workspaceName){
-    //initially, the user will need to write the name of the workspace, but when it is shown as a choose option visually (select the workspace), 
+    //initially, the user will need to write the name of the workspace, but when it is shown as a choose option visually (select the workspace),
     //there will be no need to check if the workspace exists, because the same program will identify the name and therefore pass it correctly
 
     fs::path p(DESKUPDIR);
@@ -78,7 +78,7 @@ DeskUp::Status DeskUpBackendInterface::restoreWindows(std::string workspaceName)
         if (!res.has_value()){
             if(res.error().isFatal()){
                 return std::unexpected(std::move(res.error()));
-            } 
+            }
 
             std::cout << "Unrecovered window: " << res.error().what();
         }
@@ -98,13 +98,13 @@ DeskUp::Status DeskUpBackendInterface::restoreWindows(std::string workspaceName)
         if (!loadRes.has_value()){
             if(loadRes.error().isFatal()){
                 return std::unexpected(std::move(loadRes.error()));
-            } 
+            }
 
             std::cout << "Unopened window: " << loadRes.error().what();
         }
 
         auto resizeRes = current_window_backend->resizeWindow(current_window_backend.get(), *res);
-        if (!resizeRes.has_value() && resizeRes.error().isFatal()) 
+        if (!resizeRes.has_value() && resizeRes.error().isFatal())
         if (!resizeRes.has_value()){
             if(resizeRes.error().isFatal()){
                 return std::unexpected(std::move(resizeRes.error()));
@@ -125,7 +125,7 @@ bool DeskUpBackendInterface::isWorkspaceValid(const std::string& workspaceName){
     std::string blackList = {"\\/:?*\"<>|"};
 
     for(const char c : blackList){
-        
+
         if(workspaceName.find(c) != std::string::npos){
             return false;
         }

--- a/source/desk_up_error/desk_up_error.cc
+++ b/source/desk_up_error/desk_up_error.cc
@@ -39,12 +39,15 @@ DeskUp::Error DeskUp::Error::fromLastWinError(DWORD error, std::string_view cont
         case ERROR_IO_DEVICE:
             lvl = Level::Retry; typ = ErrType::Io; break;
 
+		case ERROR_ACCESS_DISABLED_BY_POLICY:
+            lvl = Level::Skip; typ = ErrType::AccessDenied; break;
+
         case ERROR_FUNCTION_FAILED:
             lvl = Level::Retry; typ = ErrType::Unexpected; break;
 
         default:
             lvl = Level::Default; typ = ErrType::Default; break;
-    }	
+    }
 
     std::string msg = getSystemErrorMessageWindows(code, context);
     unsigned int t = tries.value_or(0);
@@ -90,6 +93,9 @@ DeskUp::Error DeskUp::Error::fromLastWinError(std::string_view context, std::opt
 
         case ERROR_FUNCTION_FAILED:
             lvl = Level::Retry; typ = ErrType::Unexpected; break;
+
+		case ERROR_INVALID_HANDLE:
+            lvl = Level::Skip; typ = ErrType::ConnectionRefused; break;
 
         default:
             lvl = Level::Default; typ = ErrType::Default; break;

--- a/source/desk_up_error/desk_up_error.cc
+++ b/source/desk_up_error/desk_up_error.cc
@@ -14,16 +14,19 @@ static std::pair<DeskUp::Level, DeskUp::ErrType> getErrType(const DWORD code) {
 
         case ERROR_NOT_ENOUGH_MEMORY:
         case ERROR_OUTOFMEMORY:
+		case ERROR_TOO_MANY_OPEN_FILES:
             lvl = DeskUp::Level::Fatal; typ = DeskUp::ErrType::InsufficientMemory; break;
 
         case ERROR_SHARING_VIOLATION:
         case ERROR_LOCK_VIOLATION:
-            lvl = DeskUp::Level::Retry; typ = DeskUp::ErrType::SharingViolation; break;
-
         case ERROR_INVALID_PARAMETER:
         case ERROR_INVALID_NAME:
         case ERROR_FILENAME_EXCED_RANGE:
+		case ERROR_BAD_FORMAT:
             lvl = DeskUp::Level::Skip; typ = DeskUp::ErrType::InvalidInput; break;
+
+		case ERROR_DLL_NOT_FOUND:
+            lvl = DeskUp::Level::Warning; typ = DeskUp::ErrType::PolicyUpdated; break;
 
         case ERROR_FILE_NOT_FOUND:
         case ERROR_PATH_NOT_FOUND:

--- a/source/desk_up_error/desk_up_error.cc
+++ b/source/desk_up_error/desk_up_error.cc
@@ -79,29 +79,30 @@ DeskUp::Error DeskUp::Error::fromLastWinError(std::string_view context, std::opt
 #endif
 
 DeskUp::Error DeskUp::Error::fromSaveError(int e){
-     switch (e) {
-        case 1:
-            return Error(Level::Info, ErrType::None, e, "windowDesc::saveTo: operation successful");
+    switch (e) {
 
-        case -1:
-            return Error(Level::Error, ErrType::InvalidInput, e, "windowDesc::saveTo: file path is empty");
+        case 1: // SaveErrorCode::SAVE_SUCCESS
+            return Error(Level::Info, ErrType::None, e, "saveTo|success");
 
-        case -2:
-            return Error(Level::Error, ErrType::Io, e, "windowDesc::saveTo: could not open file");
+        case -1: // SaveErrorCode::ERR_EMPTY_PATH
+            return Error(Level::Error, ErrType::InvalidInput, e, "saveTo|path_empty");
 
-        case -3:
-            return Error(Level::Error, ErrType::AccessDenied, e, "windowDesc::saveTo: permission denied");
+        case -2: // SaveErrorCode::ERR_FILE_NOT_OPEN
+            return Error(Level::Error, ErrType::Io, e, "saveTo|file_unopened");
 
-        case -4:
-            return Error(Level::Error, ErrType::FileNotFound, e, "windowDesc::saveTo: file or directory not found");
+        case -3: // SaveErrorCode::ERR_NO_PERMISSION
+            return Error(Level::Error, ErrType::AccessDenied, e, "saveTo|permission_denied");
 
-        case -5:
-            return Error(Level::Fatal, ErrType::DiskFull, e, "windowDesc::saveTo: disk full or no space left");
+        case -4: // SaveErrorCode::ERR_FILE_NOT_FOUND
+            return Error(Level::Error, ErrType::FileNotFound, e, "saveTo|not_found");
 
-        case -6:
-            return Error(Level::Error, ErrType::Unexpected, e, "windowDesc::saveTo: unknown I/O error");
+        case -5: // SaveErrorCode::ERR_DISK_FULL
+            return Error(Level::Fatal, ErrType::DiskFull, e, "saveTo|no_space_left");
 
-        default:
-            return Error(Level::Warning, ErrType::Default, e, "windowDesc::saveTo: unrecognized error code");
+        case -6: // SaveErrorCode::ERR_UNKNOWN
+            return Error(Level::Error, ErrType::Unexpected, e, "saveTo|unknown_error");
+
+        default: // other
+            return Error(Level::Warning, ErrType::Default, e, "saveTo|unrecognized_error");
     }
 }

--- a/source/desk_up_error/desk_up_error.cc
+++ b/source/desk_up_error/desk_up_error.cc
@@ -24,11 +24,11 @@ DeskUp::Error DeskUp::Error::fromLastWinError(DWORD error, std::string_view cont
         case ERROR_INVALID_PARAMETER:
         case ERROR_INVALID_NAME:
         case ERROR_FILENAME_EXCED_RANGE:
-            lvl = Level::Fatal; typ = ErrType::InvalidInput; break;
+            lvl = Level::Skip; typ = ErrType::InvalidInput; break;
 
         case ERROR_FILE_NOT_FOUND:
         case ERROR_PATH_NOT_FOUND:
-            lvl = Level::Default; typ = ErrType::InvalidInput; break;
+            lvl = Level::Skip; typ = ErrType::InvalidInput; break;
 
         case ERROR_DISK_FULL:
             lvl = Level::Fatal; typ = ErrType::Io; break;
@@ -44,7 +44,7 @@ DeskUp::Error DeskUp::Error::fromLastWinError(DWORD error, std::string_view cont
 
         default:
             lvl = Level::Default; typ = ErrType::Default; break;
-    }
+    }	
 
     std::string msg = getSystemErrorMessageWindows(code, context);
     unsigned int t = tries.value_or(0);
@@ -73,11 +73,11 @@ DeskUp::Error DeskUp::Error::fromLastWinError(std::string_view context, std::opt
         case ERROR_INVALID_PARAMETER:
         case ERROR_INVALID_NAME:
         case ERROR_FILENAME_EXCED_RANGE:
-            lvl = Level::Fatal; typ = ErrType::InvalidInput; break;
+            lvl = Level::Skip; typ = ErrType::InvalidInput; break;
 
         case ERROR_FILE_NOT_FOUND:
         case ERROR_PATH_NOT_FOUND:
-            lvl = Level::Default; typ = ErrType::InvalidInput; break;
+            lvl = Level::Skip; typ = ErrType::InvalidInput; break;
 
         case ERROR_DISK_FULL:
             lvl = Level::Fatal; typ = ErrType::Io; break;
@@ -90,7 +90,6 @@ DeskUp::Error DeskUp::Error::fromLastWinError(std::string_view context, std::opt
 
         case ERROR_FUNCTION_FAILED:
             lvl = Level::Retry; typ = ErrType::Unexpected; break;
-
 
         default:
             lvl = Level::Default; typ = ErrType::Default; break;

--- a/source/desk_up_error/desk_up_error.cc
+++ b/source/desk_up_error/desk_up_error.cc
@@ -44,11 +44,15 @@ static std::pair<DeskUp::Level, DeskUp::ErrType> getErrType(const DWORD code) {
         case ERROR_FUNCTION_FAILED:
             lvl = DeskUp::Level::Retry; typ = DeskUp::ErrType::Unexpected; break;
 
+		case ERROR_INVALID_WINDOW_STYLE:
+			lvl = DeskUp::Level::Info; typ = DeskUp::ErrType::ResourceBusy; break;
+
 		case ERROR_ACCESS_DISABLED_BY_POLICY:
             lvl = DeskUp::Level::Skip; typ = DeskUp::ErrType::Default; break;
 
 
 		case ERROR_INVALID_HANDLE:
+		case ERROR_INVALID_WINDOW_HANDLE:
             lvl = DeskUp::Level::Skip; typ = DeskUp::ErrType::ConnectionRefused; break;
 
         default:

--- a/source/desk_up_error/desk_up_error.h
+++ b/source/desk_up_error/desk_up_error.h
@@ -187,8 +187,11 @@ namespace DeskUp {
 		/// @brief Whether the error is skipable.
 		bool isSkippable() const noexcept { return lvl == Level::Skip; }
 
-		/// @brief Whether the error is skipable.
+		/// @brief Whether the error is a warning.
 		bool isWarning() const noexcept { return lvl == Level::Warning; }
+
+		/// @brief Whether the error is a system error.
+		bool isError() const noexcept { return lvl == Level::Error; }
 
         /// @brief Whether the error can be retried.
         bool isRetryable() const noexcept { return lvl == Level::Retry; }

--- a/source/desk_up_error/desk_up_error.h
+++ b/source/desk_up_error/desk_up_error.h
@@ -187,6 +187,9 @@ namespace DeskUp {
 		/// @brief Whether the error is skipable.
 		bool isSkippable() const noexcept { return lvl == Level::Skip; }
 
+		/// @brief Whether the error is skipable.
+		bool isWarning() const noexcept { return lvl == Level::Warning; }
+
         /// @brief Whether the error can be retried.
         bool isRetryable() const noexcept { return lvl == Level::Retry; }
 

--- a/source/desk_up_error/desk_up_error.h
+++ b/source/desk_up_error/desk_up_error.h
@@ -184,8 +184,11 @@ namespace DeskUp {
         /// @brief Whether the error is fatal.
         bool isFatal() const noexcept { return lvl == Level::Fatal; }
 
+		/// @brief Whether the error is skipable.
+		bool isSkippable() const noexcept { return lvl == Level::Skip; }
+
         /// @brief Whether the error can be retried.
-        bool isRetriable() const noexcept { return lvl == Level::Retry; }
+        bool isRetryable() const noexcept { return lvl == Level::Retry; }
 
         /// @brief Converts to `true` if this instance represents an actual error.
         explicit operator bool() const noexcept { return lvl != Level::None; }

--- a/source/desk_up_error/desk_up_error.h
+++ b/source/desk_up_error/desk_up_error.h
@@ -107,6 +107,7 @@ namespace DeskUp {
         ProtocolError,        /**< Violation of expected protocol behavior. */
         Unexpected,           /**< Unexpected runtime condition. */
         NotImplemented,       /**< Feature not yet implemented. */
+		PolicyUpdated,
         Default,              /**< Unspecified error type. */
         None                  /**< Represents no error. */
     };

--- a/source/desk_up_error/desk_up_error.h
+++ b/source/desk_up_error/desk_up_error.h
@@ -107,7 +107,8 @@ namespace DeskUp {
         ProtocolError,        /**< Violation of expected protocol behavior. */
         Unexpected,           /**< Unexpected runtime condition. */
         NotImplemented,       /**< Feature not yet implemented. */
-		PolicyUpdated,
+		PolicyUpdated,		  /**< External factors like dll dependencies have changed. */
+		FunctionFailed,		  /**< Generic function fail. */
         Default,              /**< Unspecified error type. */
         None                  /**< Represents no error. */
     };

--- a/source/desk_up_error/desk_up_error.h
+++ b/source/desk_up_error/desk_up_error.h
@@ -70,6 +70,7 @@ namespace DeskUp {
         Info,
         Debug,
         Default,
+		Skip,
         None
     };
 
@@ -220,7 +221,7 @@ namespace DeskUp {
          * @date 2025
          */
         static Error fromLastWinError(std::string_view context = "", std::optional<unsigned int> tries = std::nullopt);
-		
+
         #endif
 
         /**

--- a/source/desk_up_error_gui_converter/desk_up_error_gui_converter.cc
+++ b/source/desk_up_error_gui_converter/desk_up_error_gui_converter.cc
@@ -28,6 +28,7 @@ std::pair<QString, QMessageBox::Icon> ErrorAdapter::mapLevel(Level lvl)
     }
 }
 
+//todo: append the message of the error to the dialog
 QString ErrorAdapter::getUserMessage(const DeskUp::Error& err)
 {
     switch (err.type()) {

--- a/source/desk_up_frontend/mainWindow.cpp
+++ b/source/desk_up_frontend/mainWindow.cpp
@@ -6,7 +6,7 @@
 #include <QInputDialog>
 #include <QString>
 #include <QAction>
-#include <QStatusBar> 
+#include <QStatusBar>
 
 #include "desk_up_error.h"
 #include "window_core.h"
@@ -100,7 +100,18 @@ void MainWindow::onAddWorkspace(){
 
     if (!DeskUpBackendInterface::existsWorkspace(ws)) {
         if (auto saveRes = DeskUpBackendInterface::saveAllWindowsLocal(ws); !saveRes.has_value()) {
-            DeskUp::UI::ErrorAdapter::showError(std::move(saveRes.error()));
+
+			//this should take care of showing the message depending on the severity, and then outside the function close the program if needed
+			DeskUp::UI::ErrorAdapter::showError(std::move(saveRes.error()));
+
+			auto saveErr = saveRes.error();
+			if(saveErr.isFatal()){
+				//for now just close the program
+				
+				// QApplication::exit();
+				exit(1);
+			}
+
         } else {
             showSaveSuccessful();
         }

--- a/source/desk_up_frontend/mainWindow.cpp
+++ b/source/desk_up_frontend/mainWindow.cpp
@@ -107,7 +107,7 @@ void MainWindow::onAddWorkspace(){
 			auto saveErr = saveRes.error();
 			if(saveErr.isFatal()){
 				//for now just close the program
-				
+
 				// QApplication::exit();
 				exit(1);
 			}
@@ -162,6 +162,14 @@ void MainWindow::onRestoreWorkspace()
     if (DeskUpBackendInterface::existsWorkspace(ws)) {
         if (auto res = DeskUpBackendInterface::restoreWindows(ws); !res.has_value()) {
             DeskUp::UI::ErrorAdapter::showError(std::move(res.error()));
+
+			auto restoreErr = res.error();
+			if(restoreErr.isFatal()){
+				//for now just close the program
+
+				// QApplication::exit();
+				exit(1);
+			}
         } else {
             showRestoreSuccessful();
         }

--- a/source/desk_up_window_backend/backend_utils/backend_utils.cc
+++ b/source/desk_up_window_backend/backend_utils/backend_utils.cc
@@ -45,9 +45,9 @@ std::string getSystemErrorMessageWindows(DWORD error, const std::string_view& co
         0,
         nullptr
     );
-    
+
     std::string finalMessage;
-    
+
     finalMessage = contextMessage;
     if (charsWritten && messageBuffer) {
         // Copy the wide string into std::wstring and trim trailing CR/LF.
@@ -60,10 +60,10 @@ std::string getSystemErrorMessageWindows(DWORD error, const std::string_view& co
         LocalFree(messageBuffer);
 
         // Build the final message string: context text + translated system error.
-        finalMessage += utf8.empty() ? "Unknown Windows error." : utf8;
+        finalMessage += utf8.empty() ? "|no_error" : (std::string)("|") + utf8;
     } else {
         // If FormatMessageW failed, fall back to a generic message.
-        finalMessage += "Unknown Windows error.";
+        finalMessage += "|no_error";
     }
 
     return finalMessage;
@@ -86,7 +86,7 @@ std::wstring UTF8ToWide(const std::string& s){
 #endif
 
 std::string toLowerStr(const std::string& s){
-    
+
     std::string res;
     res.reserve(s.size());
     for (unsigned char c : s) {

--- a/source/desk_up_window_backend/backend_utils/backend_utils.cc
+++ b/source/desk_up_window_backend/backend_utils/backend_utils.cc
@@ -60,10 +60,10 @@ std::string getSystemErrorMessageWindows(DWORD error, const std::string_view& co
         LocalFree(messageBuffer);
 
         // Build the final message string: context text + translated system error.
-        finalMessage += utf8.empty() ? "|no_error" : (std::string)("|") + utf8;
+        finalMessage += utf8.empty() ? "no_error" : (std::string)("") + utf8;
     } else {
         // If FormatMessageW failed, fall back to a generic message.
-        finalMessage += "|no_error";
+        finalMessage += "no_error";
     }
 
     return finalMessage;

--- a/source/desk_up_window_backend/desk_up_window_device.h
+++ b/source/desk_up_window_backend/desk_up_window_device.h
@@ -35,16 +35,18 @@
 #include "window_desc.h"
 #include "desk_up_error.h"
 
+namespace fs = std::filesystem;
+
 /**
  * @struct DeskUpWindowDevice
  * @brief This abstract struct represents all the common calls that any backend must have.
- * 
+ *
  * @details  There are multiple pointers to functions inside this struct. Each one of them gets connected to a backend function whenever
  *           the backend gets created. When invoking the pointer, it implicitly calls the correct backend function, thus giving the
  *           expected result for that specific backend.
- *           This struct also carries specific backend information needed to get information from a backend successfully. 
- *           
- * 
+ *           This struct also carries specific backend information needed to get information from a backend successfully.
+ *
+ *
  * @see windowData
  * @author Nicolas Serrano Garcia <serranogarcianicolas@gmail.com>
  * @version 0.1.0
@@ -54,7 +56,7 @@ struct DeskUpWindowDevice{
 
     /**
      * @brief A pointer to function that is used to get the height of a window.
-     * 
+     *
      * @param _this The very same instance
      * @return An \c unsigned \c int representing the height of the window
      * @version 0.1.0
@@ -64,7 +66,7 @@ struct DeskUpWindowDevice{
 
     /**
      * @brief A pointer to function that is used to get the width of a window.
-     * 
+     *
      * @param _this The very same instance
      * @return An \c unsigned \c int representing the width of the window
      * @version 0.1.0
@@ -74,7 +76,7 @@ struct DeskUpWindowDevice{
 
     /**
      * @brief A pointer to function that is used to get the X position of a the top left corner of a window.
-     * 
+     *
      * @param _this The very same instance
      * @return An \c int representing the X position of the top left corner of a window
      * @version 0.1.0
@@ -84,7 +86,7 @@ struct DeskUpWindowDevice{
 
     /**
      * @brief A pointer to function that is used to get the Y position of a the top left corner of a window.
-     * 
+     *
      * @param _this The very same instance
      * @return An \c int representing the Y position of the top left corner of a window
      * @version 0.1.0
@@ -92,24 +94,32 @@ struct DeskUpWindowDevice{
      */
     DeskUp::Result<int> (*getWindowYPos)(DeskUpWindowDevice * _this);
 
-    DeskUp::Result<std::string> (*getPathFromWindow)(DeskUpWindowDevice * _this);
+	/**
+     * @brief A pointer to function that is used to get the path to the executable that created the window
+     *
+     * @param _this The very same instance
+     * @return An \c filesystem::path representing the path of the window
+     * @version 0.1.0
+     * @date 2025
+     */
+    DeskUp::Result<fs::path> (*getPathFromWindow)(DeskUpWindowDevice * _this);
 
     /**
      * @brief A pointer to function that is used to get the generic DeskUp workspaces path.
-     * 
+     *
      * @details The return path is the path to the top-level folder where all the user workspaces are saved. A workspace
      * whose name is "foo" will have it's information saved in \c getDeskUpPath() \c + \c "/foo"
-     * 
+     *
      * @return An \c std::string representing the path to the top-level Desk Up workspaces folder
      * @version 0.1.0
      * @date 2025
      */
     DeskUp::Result<std::string> (*getDeskUpPath)(void);
-    
+
     /**
-     * @brief A pointer to function that is used to get a list of abstract windows. For any backend to return the same thing, 
+     * @brief A pointer to function that is used to get a list of abstract windows. For any backend to return the same thing,
      * an abstract struct representing a windows is created. Regardless of the implementation, every device returns a vector of this type.
-     * 
+     *
      * @param _this The very same instance
      * @return An \c std::vector representing all the visible and non-minimized windows currently open
      * @version 0.1.0
@@ -118,19 +128,19 @@ struct DeskUpWindowDevice{
     DeskUp::Result<std::vector<windowDesc>> (*getAllOpenWindows)(DeskUpWindowDevice * _this);
 
     /**
-     * @brief A pointer to function that is used to open a window from a given path. If the path is empty, 
-     * 
+     * @brief A pointer to function that is used to open a window from a given path. If the path is empty,
+     *
      * @param _this The very same instance
      * @param path a \c const \c char* to the executable
      * @return \c void
      * @version 0.2.0
      * @date 2025
      */
-    DeskUp::Status (*loadWindowFromPath)(DeskUpWindowDevice * _this, const std::string path);
+    DeskUp::Status (*loadWindowFromPath)(DeskUpWindowDevice * _this, const fs::path& path);
 
     /**
      * @brief A pointer to function that is used to recover a window from a deskUp file, which shall be located inside appData\DeskUp
-     * 
+     *
      * @param _this The very same instance
      * @param path a \c const \c char* to the executable
      * @return A \c windowDesc representing the recovered window. If any of the recovery processes fails, the associated field will be set to
@@ -138,14 +148,14 @@ struct DeskUpWindowDevice{
      * @version 0.2.0
      * @date 2025
      */
-    DeskUp::Result<windowDesc> (*recoverSavedWindow)(DeskUpWindowDevice * _this, std::filesystem::path filePath);
+    DeskUp::Result<windowDesc> (*recoverSavedWindow)(DeskUpWindowDevice * _this, const fs::path& filePath);
 
     /**
      * @brief A pointer to function that is used to resize a given window.
-     * 
+     *
      * @details Information about the window whose geometry is intended to modify must be specified inside the \c _this->internalData parameter
-     * 
-     * 
+     *
+     *
      * @param _this The very same instance
      * @param path a \c windowDesc instance whose geometry wants to be used for the resizing
      * @return A \c void
@@ -156,7 +166,7 @@ struct DeskUpWindowDevice{
 
         /**
      * @brief A pointer to function that is used to close all the windows associated with a given path.
-     * 
+     *
      * @param _this The very same instance
      * @param path a \c std::string instance that represents the path
      * @param allowForce Whether if the call should force the program to close
@@ -164,17 +174,17 @@ struct DeskUpWindowDevice{
      * @version 0.2.0
      * @date 2025
      */
-    DeskUp::Result<unsigned int> (*closeProcessFromPath)(DeskUpWindowDevice * _this, const std::string& path, bool allowForce);
+    DeskUp::Result<unsigned int> (*closeProcessFromPath)(DeskUpWindowDevice * _this, const fs::path& path, bool allowForce);
 
     /**
      * @brief A pointer that points to the specific information needed by each backend
-     * 
+     *
      * @details each backend defines WindowData, which is the template to seek the values of this pointer. Whenever a device call wants to access
      *          backend-specific info, this pointer gets casted to \c windowData* by \c std::reinterpret_cast. Then the backend accesses whatever
-     *          information it needs. Finally, the same call casts back this pointer to \c void* , leaving everything as it was. 
+     *          information it needs. Finally, the same call casts back this pointer to \c void* , leaving everything as it was.
      *          One can interpret this pointer as a "black box", or a "pouch", where the info gets thrown inside, and then reinterpreted back whenever
      *          it is needed
-     * 
+     *
      * @version 0.1.0
      * @date 2025
      */

--- a/source/desk_up_window_backend/desk_up_window_device.h
+++ b/source/desk_up_window_backend/desk_up_window_device.h
@@ -164,7 +164,7 @@ struct DeskUpWindowDevice{
      */
     DeskUp::Status (*resizeWindow)(DeskUpWindowDevice * _this, const windowDesc window);
 
-        /**
+    /**
      * @brief A pointer to function that is used to close all the windows associated with a given path.
      *
      * @param _this The very same instance
@@ -189,6 +189,16 @@ struct DeskUpWindowDevice{
      * @date 2025
      */
     void * internalData;
+
+    /**
+     * @brief A pointer to function that is used to delete the device. Each device defines it's own deleter, which then gets called
+	 * in the wrapper DU_destroy inside window_core.cc
+     *
+     * @param _this The very same instance
+     * @version 0.3.2
+     * @date 2025
+     */
+	void (*DestroyDevice)(DeskUpWindowDevice * _this);
 };
 
 #endif

--- a/source/desk_up_window_backend/window_backends/desk_up_win/desk_up_win.cc
+++ b/source/desk_up_window_backend/window_backends/desk_up_win/desk_up_win.cc
@@ -110,10 +110,15 @@ DeskUpWindowDevice WIN_CreateDevice() noexcept{
     device.recoverSavedWindow = WIN_recoverSavedWindow;
     device.resizeWindow    = WIN_resizeWindow;
     device.closeProcessFromPath = WIN_closeProcessFromPath;
+	device.DestroyDevice = WIN_destroyDevice;
 
     device.internalData = (void *) new windowData();
 
     return device;
+}
+
+void WIN_destroyDevice(DeskUpWindowDevice* _this) noexcept {
+	delete getWindowData(_this);
 }
 
 DeskUp::Result<std::string> WIN_getDeskUpPath() noexcept{

--- a/source/desk_up_window_backend/window_backends/desk_up_win/desk_up_win.h
+++ b/source/desk_up_window_backend/window_backends/desk_up_win/desk_up_win.h
@@ -74,7 +74,7 @@ bool WIN_isAvailable() noexcept;
  * @version 0.1.0
  * @date 2025
  */
-DeskUpWindowDevice WIN_CreateDevice();
+DeskUpWindowDevice WIN_CreateDevice() noexcept;
 
 /**
  * @brief Returns the base DeskUp working path on the system.
@@ -88,7 +88,7 @@ DeskUpWindowDevice WIN_CreateDevice();
  * @version 0.1.0
  * @date 2025
  */
-DeskUp::Result<std::string> WIN_getDeskUpPath();
+DeskUp::Result<std::string> WIN_getDeskUpPath() noexcept;
 
 /**
  * @brief Gets the X position (top-left corner) of the active (client) window in the device.
@@ -101,7 +101,7 @@ DeskUp::Result<std::string> WIN_getDeskUpPath();
  * @version 0.1.0
  * @date 2025
  */
-DeskUp::Result<int> WIN_getWindowXPos(DeskUpWindowDevice * _this);
+DeskUp::Result<int> WIN_getWindowXPos(DeskUpWindowDevice * _this) noexcept;
 
 /**
  * @brief Gets the Y position (top-left corner) of the active (client) window in the device.
@@ -114,7 +114,7 @@ DeskUp::Result<int> WIN_getWindowXPos(DeskUpWindowDevice * _this);
  * @version 0.1.0
  * @date 2025
  */
-DeskUp::Result<int> WIN_getWindowYPos(DeskUpWindowDevice * _this);
+DeskUp::Result<int> WIN_getWindowYPos(DeskUpWindowDevice * _this) noexcept;
 
 /**
  * @brief Gets the width of the active (client) window in the device.
@@ -127,7 +127,7 @@ DeskUp::Result<int> WIN_getWindowYPos(DeskUpWindowDevice * _this);
  * @version 0.1.0
  * @date 2025
  */
-DeskUp::Result<unsigned int> WIN_getWindowWidth(DeskUpWindowDevice * _this);
+DeskUp::Result<unsigned int> WIN_getWindowWidth(DeskUpWindowDevice * _this) noexcept;
 
 /**
  * @brief Gets the height of the active (client) window in the device.
@@ -140,7 +140,7 @@ DeskUp::Result<unsigned int> WIN_getWindowWidth(DeskUpWindowDevice * _this);
  * @version 0.1.0
  * @date 2025
  */
-DeskUp::Result<unsigned int> WIN_getWindowHeight(DeskUpWindowDevice * _this);
+DeskUp::Result<unsigned int> WIN_getWindowHeight(DeskUpWindowDevice * _this) noexcept;
 
 /**
  * @brief Gets the absolute path of the executable that owns the active window.
@@ -154,7 +154,7 @@ DeskUp::Result<unsigned int> WIN_getWindowHeight(DeskUpWindowDevice * _this);
  * @version 0.1.0
  * @date 2025
  */
-DeskUp::Result<std::string> WIN_getPathFromWindow(DeskUpWindowDevice * _this);
+DeskUp::Result<std::string> WIN_getPathFromWindow(DeskUpWindowDevice * _this) noexcept;
 
 /**
  * @brief Enumerates all visible/non-minimized windows on the desktop.
@@ -167,7 +167,7 @@ DeskUp::Result<std::string> WIN_getPathFromWindow(DeskUpWindowDevice * _this);
  * @version 0.1.0
  * @date 2025
  */
-DeskUp::Result<std::vector<windowDesc>> WIN_getAllOpenWindows(DeskUpWindowDevice * _this);
+DeskUp::Result<std::vector<windowDesc>> WIN_getAllOpenWindows(DeskUpWindowDevice * _this) noexcept;
 
 /**
  * @brief Loads a window description from a saved workspace file.
@@ -214,7 +214,7 @@ DeskUp::Status WIN_loadProcessFromPath(DeskUpWindowDevice * _this, std::string p
  * @version 0.2.0
  * @date 2025
  */
-DeskUp::Status WIN_resizeWindow(DeskUpWindowDevice * _this, const windowDesc window);
+DeskUp::Status WIN_resizeWindow(DeskUpWindowDevice * _this, const windowDesc window) noexcept;
 
 /**
  * @brief This function closes all the instances associated with an executable, specified by the \c path parameter.
@@ -229,7 +229,7 @@ DeskUp::Status WIN_resizeWindow(DeskUpWindowDevice * _this, const windowDesc win
  * @version 0.2.0
  * @date 2025
  */
-DeskUp::Result<unsigned int> WIN_closeProcessFromPath(DeskUpWindowDevice*, const std::string& path, bool allowForce);
+DeskUp::Result<unsigned int> WIN_closeProcessFromPath(DeskUpWindowDevice*, const std::string& path, bool allowForce) noexcept;
 
 /**
  * @brief Test-only helper to set the internal HWND for the device.

--- a/source/desk_up_window_backend/window_backends/desk_up_win/desk_up_win.h
+++ b/source/desk_up_window_backend/window_backends/desk_up_win/desk_up_win.h
@@ -79,6 +79,15 @@ bool WIN_isAvailable() noexcept;
 DeskUpWindowDevice WIN_CreateDevice() noexcept;
 
 /**
+ * @brief Deletes a Windows \c DeskUpWindowDevice. Deletion is done as a wrapper function in window_core.cc,
+ * done by DU_destroy via the pointer function
+ *
+ * @version 0.3.2
+ * @date 2025
+ */
+void WIN_destroyDevice(DeskUpWindowDevice* _this) noexcept;
+
+/**
  * @brief Returns the base DeskUp working path on the system.
  *
  * @details Points to the top-level directory where user workspaces are stored.

--- a/source/desk_up_window_backend/window_core/window_core.cc
+++ b/source/desk_up_window_backend/window_core/window_core.cc
@@ -19,12 +19,12 @@ int DU_Init(){
     #endif
 
     DeskUpWindowDevice dev;
-    
+
     std::string devName;
 
     bool assigned = false;
     for(unsigned int i = 0; i < devices.size(); i++){
-        
+
         if(!devices[i].isAvailable()){
             std::cout << devices[i].name << " is not an available backend on this system: Exiting" << std::endl;
             continue;
@@ -46,10 +46,17 @@ int DU_Init(){
         return 0;
     }
 
-    std::cout << "DeskUp path: " << DESKUPDIR << std::endl; 
+    std::cout << "DeskUp path: " << DESKUPDIR << std::endl;
 
     current_window_backend = std::make_unique<DeskUpWindowDevice>(dev);
     std::cout << devName << " successfully connected as a backend!" << std::endl;
-    
+
     return 1;
+}
+
+void DU_Destroy(){
+	current_window_backend.get()->DestroyDevice(current_window_backend.get());
+    current_window_backend.reset();
+    DESKUPDIR.clear();
+    devices.clear();
 }

--- a/source/desk_up_window_backend/window_core/window_core.h
+++ b/source/desk_up_window_backend/window_core/window_core.h
@@ -94,4 +94,21 @@ extern std::unique_ptr<DeskUpWindowDevice> current_window_backend;
  */
 int DU_Init();
 
+/**
+ * @brief Destroys and cleans up the DeskUp backend resources.
+ *
+ * @details
+ * Releases the backend device and clears global state.
+ * Should be called when DeskUp is no longer needed to free resources.
+ * After calling this function, DU_Init() must be called again before
+ * using any DeskUp functionality.
+ *
+ * @note Safe to call even if DU_Init() was not called or failed.
+ *
+ * @see DU_Init()
+ * @version 0.1.1
+ * @date 2025
+ */
+void DU_Destroy();
+
 #endif

--- a/source/desk_up_window_backend/window_desc/window_desc.h
+++ b/source/desk_up_window_backend/window_desc/window_desc.h
@@ -73,8 +73,18 @@ struct windowDesc {
 	 * @param h Height in pixels.
 	 * @param p Absolute path to the owning executable.
 	 */
-	windowDesc(std::string n, int xPos, int yPos, int width, int height, std::string p) : name(n), x(xPos), y(yPos), w(width), h(height), pathToExec(p) {}
+	windowDesc(std::string n, int xPos, int yPos, int width, int height, std::string p) : name(n), x(xPos), y(yPos), w(width), h(height), pathToExec(fs::path(p)) {}
 
+	/**
+	 * @brief Constructs a window descriptor with explicit name, geometry, and executable path.
+	 * @param n window name.
+	 * @param x X coordinate (top-left) in pixels.
+	 * @param y Y coordinate (top-left) in pixels.
+	 * @param w Width in pixels.
+	 * @param h Height in pixels.
+	 * @param p Absolute path to the owning executable.
+	 */
+	windowDesc(std::string n, int xPos, int yPos, int width, int height, fs::path p) : name(n), x(xPos), y(yPos), w(width), h(height), pathToExec(p) {}
 
     /**
      * @brief The window name.
@@ -105,7 +115,7 @@ struct windowDesc {
     /**
      * @brief The absolute path to the executable that owns this window.
      */
-    std::string pathToExec;
+    fs::path pathToExec;
 
     /**
      * @brief Saves the current window description to a file.

--- a/source/desk_up_window_backend/window_desc/window_desc.h
+++ b/source/desk_up_window_backend/window_desc/window_desc.h
@@ -75,16 +75,16 @@ struct windowDesc {
 	 */
 	windowDesc(std::string n, int xPos, int yPos, int width, int height, std::string p) : name(n), x(xPos), y(yPos), w(width), h(height), pathToExec(fs::path(p)) {}
 
-	/**
-	 * @brief Constructs a window descriptor with explicit name, geometry, and executable path.
-	 * @param n window name.
-	 * @param x X coordinate (top-left) in pixels.
-	 * @param y Y coordinate (top-left) in pixels.
-	 * @param w Width in pixels.
-	 * @param h Height in pixels.
-	 * @param p Absolute path to the owning executable.
-	 */
-	windowDesc(std::string n, int xPos, int yPos, int width, int height, fs::path p) : name(n), x(xPos), y(yPos), w(width), h(height), pathToExec(p) {}
+	// /**
+	//  * @brief Constructs a window descriptor with explicit name, geometry, and executable path.
+	//  * @param n window name.
+	//  * @param x X coordinate (top-left) in pixels.
+	//  * @param y Y coordinate (top-left) in pixels.
+	//  * @param w Width in pixels.
+	//  * @param h Height in pixels.
+	//  * @param p Absolute path to the owning executable.
+	//  */
+	// windowDesc(std::string n, int xPos, int yPos, int width, int height, fs::path p) : name(n), x(xPos), y(yPos), w(width), h(height), pathToExec(p) {}
 
     /**
      * @brief The window name.

--- a/test/desk_up_backend_interface_test/desk_up_dummy_device.h
+++ b/test/desk_up_backend_interface_test/desk_up_dummy_device.h
@@ -73,15 +73,20 @@ inline DeskUp::Result<int> DUMMY_getWindowYPos(DeskUpWindowDevice* _this) {
     return data->y;
 }
 
-inline DeskUp::Result<std::string> DUMMY_getPathFromWindow(DeskUpWindowDevice* _this) {
+inline DeskUp::Result<fs::path> DUMMY_getPathFromWindow(DeskUpWindowDevice* _this) {
     auto* data = static_cast<DummyDeviceData*>(_this->internalData);
     if (data->simulateError) return std::unexpected(data->errorToReturn);
-    return data->path;
+    return fs::path(data->path);
 }
 
 inline DeskUp::Result<std::string> DUMMY_getDeskUpPath() {
     // Return a test-specific path
-    return std::filesystem::temp_directory_path().string() + "/DeskUpTest";
+
+	fs::path ret = std::filesystem::temp_directory_path();
+
+	ret /= "DeskUpTest";
+
+    return ret.string();
 }
 
 inline DeskUp::Result<std::vector<windowDesc>> DUMMY_getAllOpenWindows(DeskUpWindowDevice* _this) {
@@ -102,7 +107,7 @@ inline DeskUp::Result<std::vector<windowDesc>> DUMMY_getAllOpenWindows(DeskUpWin
     return data->windows;
 }
 
-inline DeskUp::Status DUMMY_loadWindowFromPath(DeskUpWindowDevice* _this, const std::string path) {
+inline DeskUp::Status DUMMY_loadWindowFromPath(DeskUpWindowDevice* _this, const fs::path& path) {
     auto* data = static_cast<DummyDeviceData*>(_this->internalData);
     if (data->simulateError) return std::unexpected(data->errorToReturn);
     if (path.empty()) {
@@ -110,11 +115,11 @@ inline DeskUp::Status DUMMY_loadWindowFromPath(DeskUpWindowDevice* _this, const 
             DeskUp::Level::Fatal, DeskUp::ErrType::InvalidInput, 0, "Empty path"
         ));
     }
-    data->path = path;
+    data->path = path.string();
     return {};
 }
 
-inline DeskUp::Result<windowDesc> DUMMY_recoverSavedWindow(DeskUpWindowDevice* _this, std::filesystem::path filePath) {
+inline DeskUp::Result<windowDesc> DUMMY_recoverSavedWindow(DeskUpWindowDevice* _this, const fs::path& filePath) {
     auto* data = static_cast<DummyDeviceData*>(_this->internalData);
     if (data->simulateError) return std::unexpected(data->errorToReturn);
 
@@ -140,7 +145,7 @@ inline DeskUp::Status DUMMY_resizeWindow(DeskUpWindowDevice* _this, const window
     return {};
 }
 
-inline DeskUp::Result<unsigned int> DUMMY_closeProcessFromPath(DeskUpWindowDevice* _this, const std::string& path, bool allowForce) {
+inline DeskUp::Result<unsigned int> DUMMY_closeProcessFromPath(DeskUpWindowDevice* _this, const fs::path& path, bool allowForce) {
     auto* data = static_cast<DummyDeviceData*>(_this->internalData);
     if (data->simulateError) return std::unexpected(data->errorToReturn);
 

--- a/test/desk_up_error_test/desk_up_error_test.cc
+++ b/test/desk_up_error_test/desk_up_error_test.cc
@@ -89,19 +89,19 @@ TEST(DeskUpErrorTest, whichWindowDefault){
     EXPECT_TRUE(wd.pathToExec.empty());
 }
 
-// isFatal() and isRetriable() positive and negative cases.
+// isFatal() and isRetryable() positive and negative cases.
 TEST(DeskUpErrorTest, isFatalAndRetriable){
     Error fatalErr(Level::Fatal, ErrType::Unexpected, 0, "fatal");
     EXPECT_TRUE(fatalErr.isFatal());
-    EXPECT_FALSE(fatalErr.isRetriable());
+    EXPECT_FALSE(fatalErr.isRetryable());
 
     Error retryErr(Level::Retry, ErrType::Io, 2, "retry");
-    EXPECT_TRUE(retryErr.isRetriable());
+    EXPECT_TRUE(retryErr.isRetryable());
     EXPECT_FALSE(retryErr.isFatal());
 
     Error normalErr(Level::Error, ErrType::Default, 0, "error");
     EXPECT_FALSE(normalErr.isFatal());
-    EXPECT_FALSE(normalErr.isRetriable());
+    EXPECT_FALSE(normalErr.isRetryable());
 }
 
 // bool operator should be false only for Level::None.

--- a/test/desk_up_window_backend_test/desk_up_window_backend_test.cc
+++ b/test/desk_up_window_backend_test/desk_up_window_backend_test.cc
@@ -326,7 +326,7 @@ TEST_F(Win32WindowFixture, GetPathFromWindowIsCurrentProcess) {
     auto path_res = WIN_getPathFromWindow(&device);
     ASSERT_TRUE(path_res.has_value()) << "Failed to get path from window";
 
-    std::string path = path_res.value();
+    std::string path = path_res.value().string();
     EXPECT_FALSE(path.empty()) << "Path should not be empty";
 
     // The path should contain the test executable name (e.g., desk_up_window_backend_test.exe)
@@ -359,7 +359,7 @@ TEST_F(Win32WindowFixture, EnumerateWindowsFindsTestWindow) {
 
     bool found_our_window = false;
     for (const auto& w : windows) {
-        if (!w.pathToExec.empty() && normalizePathLower(w.pathToExec) == our_exe) {
+        if (!w.pathToExec.empty() && normalizePathLower(w.pathToExec.string()) == our_exe) {
             // Found a window belonging to our process
             found_our_window = true;
 
@@ -412,7 +412,7 @@ TEST_F(Win32WindowFixture, EnumerateWindows_FiltersHiddenZeroSizeAndUntitled) {
     size_t ourCount = 0;
     bool foundVisibleGeometry = false;
     for (const auto& w : windowsAfter) {
-        if (!w.pathToExec.empty() && normalizePathLower(w.pathToExec) == ourExe) {
+        if (!w.pathToExec.empty() && normalizePathLower(w.pathToExec.string()) == ourExe) {
             ++ourCount;
             // Validate non-zero geometry for our process windows
             EXPECT_GT(w.w, 0u);
@@ -453,7 +453,7 @@ TEST_F(Win32WindowFixture, EnumerateWindows_SkipsDeskUpGlobalWindow) {
 
     bool foundSpecialGeometry = false;
     for (const auto& w : windows) {
-        if (!w.pathToExec.empty() && normalizePathLower(w.pathToExec) == ourExe) {
+        if (!w.pathToExec.empty() && normalizePathLower(w.pathToExec.string()) == ourExe) {
             if (std::abs((int)w.w - 321) <= 30 && std::abs((int)w.h - 123) <= 40) {
                 foundSpecialGeometry = true;
                 break;


### PR DESCRIPTION
# What's Changed

## 1. Backend Code Cleanup and Removal of Unused Components

This branch introduces a broad cleanup of the backend layer to improve maintainability and reduce technical debt.

Main contributions include:

- Removal of unused or deprecated backend modules, helper files, and interfaces that were no longer part of the current architecture.
- Consolidation of backend-related code into clearer, more cohesive units.
- Elimination of obsolete abstractions and function indirections that were left behind after previous refactors.

## 2. Folder and File Structure Reorganization

To improve clarity and long-term maintainability, several backend-related files were reorganized:

- Grouped window-handling, error-handling, and device-abstraction code into better-defined directories.
- Removed redundant headers and simplified internal includes.
- Ensured that backend logic is clearly separated from GUI logic and frontend utilities.

This reorganization makes the codebase easier to navigate and aligns with the new backend boundaries.

## 3. CMake Adjustments and Cleanup

As part of the cleanup effort, this branch includes several improvements to the build system:

- Removed unused backend source files from CMake targets.
- Updated target definitions to reflect the new backend structure.
- Fixed lingering linkage and include entries referencing removed modules.
- Ensured that no deprecated components remain declared in any build path.